### PR TITLE
Pagination proposal

### DIFF
--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -5,6 +5,7 @@ module Hcloud
   autoload :Error, 'hcloud/errors'
   autoload :Client, 'hcloud/client'
   autoload :AbstractResource, 'hcloud/abstract_resource'
+  autoload :MultiReply, 'hcloud/multi_reply'
   autoload :ServerResource, 'hcloud/server_resource'
   autoload :EntryLoader, 'hcloud/entry_loader'
   autoload :FloatingIP, 'hcloud/floating_ip'
@@ -24,4 +25,5 @@ module Hcloud
   autoload :ActionResource, 'hcloud/action_resource'
   autoload :Iso, 'hcloud/iso'
   autoload :IsoResource, 'hcloud/iso_resource'
+  autoload :Pagination, 'hcloud/pagination'
 end

--- a/lib/hcloud/abstract_resource.rb
+++ b/lib/hcloud/abstract_resource.rb
@@ -1,5 +1,7 @@
 module Hcloud
   class AbstractResource
+    include Enumerable
+
     attr_reader :client, :parent, :base_path
 
     def initialize(client:, parent: nil, base_path: "")

--- a/lib/hcloud/abstract_resource.rb
+++ b/lib/hcloud/abstract_resource.rb
@@ -5,7 +5,39 @@ module Hcloud
     def initialize(client:, parent: nil, base_path: "")
       @client = client
       @parent = parent
+      @page = 1
+      @per_page = 25
+      @order = []
       @base_path = base_path
+    end
+
+    def page(page)
+      @page = page
+      self
+    end
+
+    def per_page(per_page)
+      @per_page = per_page
+      self
+    end
+
+    def order(*sort)
+      @order = sort.flat_map do |s|
+        case s
+        when Symbol, String then s.to_s
+        when Hash then s.map { |k, v| "#{k}:#{v}" }
+        else
+          raise ArgumentError, 
+            "Unable to resolve type for given #{s.inspect} from #{sort}"
+        end
+      end
+      self
+    end
+    
+    def mj(path, **o, &block)
+      m = MultiReply.new(j: Oj.load(request(path, o.merge(ep: ep)).run.body))
+      m.cb = block
+      m
     end
     
     def each(&block)
@@ -15,6 +47,21 @@ module Hcloud
     end
 
     protected
+
+    def page_params
+      { per_page: @per_page, page: @page }.to_param
+    end
+
+    def sort_params
+      @order.to_a.map{|x| "sort=#{x}" }.join("&")
+    end
+
+    def ep
+      r = []
+      (x = page_params).empty? ? nil : r << x 
+      (x = sort_params).empty? ? nil : r << x
+      r.compact.join("&")
+    end
 
     def request(*args)
       client.request(*args)

--- a/lib/hcloud/action_resource.rb
+++ b/lib/hcloud/action_resource.rb
@@ -3,12 +3,12 @@ module Hcloud
   class ActionResource < AbstractResource
     include Enumerable
 
-    def all(sort: nil)
-      Oj.load(request(base_path("actions"), q: {sort: sort}).run.body)["actions"].map do |x|
-        Action.new(x, self, client)
+    def all
+      mj(base_path("actions")) do |j|
+        j["actions"].map{ |x| Action.new(x, self, client) }
       end
     end
-    
+
     def find(id)
       Action.new(
         Oj.load(request(base_path("actions/#{id.to_i}")).run.body)["action"], 
@@ -22,12 +22,9 @@ module Hcloud
     rescue Error::NotFound
     end
 
-    def where(status: nil, sort: nil)
-      Oj.load(
-        request(base_path("actions"), 
-                q: {status: status, sort: sort}).run.body
-      )["actions"].map do |x|
-        Action.new(x, self, client)
+    def where(status: nil)
+      mj(base_path("actions"), q: {status: status}) do |j|
+        j["actions"].map{ |x| Action.new(x, self, client) }
       end
     end
 

--- a/lib/hcloud/action_resource.rb
+++ b/lib/hcloud/action_resource.rb
@@ -1,8 +1,6 @@
 
 module Hcloud
   class ActionResource < AbstractResource
-    include Enumerable
-
     def all
       mj(base_path("actions")) do |j|
         j.flat_map{|x| x["actions"].map{ |x| Action.new(x, self, client) } }

--- a/lib/hcloud/action_resource.rb
+++ b/lib/hcloud/action_resource.rb
@@ -5,7 +5,7 @@ module Hcloud
 
     def all
       mj(base_path("actions")) do |j|
-        j["actions"].map{ |x| Action.new(x, self, client) }
+        j.flat_map{|x| x["actions"].map{ |x| Action.new(x, self, client) } }
       end
     end
 
@@ -24,7 +24,7 @@ module Hcloud
 
     def where(status: nil)
       mj(base_path("actions"), q: {status: status}) do |j|
-        j["actions"].map{ |x| Action.new(x, self, client) }
+        j.flat_map{|x| x["actions"].map{ |x| Action.new(x, self, client) }}
       end
     end
 

--- a/lib/hcloud/client.rb
+++ b/lib/hcloud/client.rb
@@ -57,9 +57,12 @@ module Hcloud
         options[:body] = Oj.dump(x, mode: :compat)
         options[:method] ||= :post
       end
+      q = []
+      q << options.delete(:ep).to_s
       if x = options.delete(:q)
-        path << "?"+x.to_param
+        q << x.to_param
       end
+      path << "?"+q.join("&")
       r = Typhoeus::Request.new(
         "https://api.hetzner.cloud/v1/#{path}",
         {

--- a/lib/hcloud/image_resource.rb
+++ b/lib/hcloud/image_resource.rb
@@ -3,8 +3,8 @@ module Hcloud
     include Enumerable
 
     def all
-      Oj.load(request("images").run.body)["images"].map do |x|
-        Image.new(x, self, client)
+      mj("images") do |j|
+        j.flat_map{|x| x["images"].map{ |x| Image.new(x, self, client) } }
       end
     end
     
@@ -33,10 +33,8 @@ module Hcloud
       method(:where).parameters.inject(query) do |r,x| 
         (var = eval(x.last.to_s)).nil? ? r : r.merge!(x.last => var)
       end
-      Oj.load(
-        request("images", q: query).run.body
-      )["images"].map do |x|
-        Image.new(x, self, client)
+      mj("images", q: query) do |j|
+        j.flat_map{|x| x["images"].map{ |x| Image.new(x, self, client) } }
       end
     end
 

--- a/lib/hcloud/image_resource.rb
+++ b/lib/hcloud/image_resource.rb
@@ -1,7 +1,5 @@
 module Hcloud
   class ImageResource < AbstractResource
-    include Enumerable
-
     def all
       mj("images") do |j|
         j.flat_map{|x| x["images"].map{ |x| Image.new(x, self, client) } }

--- a/lib/hcloud/iso_resource.rb
+++ b/lib/hcloud/iso_resource.rb
@@ -1,10 +1,8 @@
 module Hcloud
   class IsoResource < AbstractResource
-    include Enumerable
-
     def all
-      Oj.load(request("isos").run.body)["isos"].map do |x|
-        Iso.new(x, self, client)
+      mj("isos") do |j|
+        j.flat_map{|x| x["isos"].map{ |x| Iso.new(x, self, client) } }
       end
     end
 

--- a/lib/hcloud/location_resource.rb
+++ b/lib/hcloud/location_resource.rb
@@ -1,10 +1,9 @@
 module Hcloud
   class LocationResource < AbstractResource
-    include Enumerable
-
     def all
-      j = Oj.load(request("locations").run.body)
-      j["locations"].map{|x| Location.new(x, self, client) }
+      mj("locations") do |j|
+        j.flat_map{|x| x["locations"].map{ |x| Location.new(x, self, client) } }
+      end
     end
 
     def find(id)

--- a/lib/hcloud/multi_reply.rb
+++ b/lib/hcloud/multi_reply.rb
@@ -1,0 +1,21 @@
+module Hcloud
+  class MultiReply
+    include Enumerable
+    attr_accessor :cb
+
+    def initialize(j:)
+       @j = j
+    end
+
+    def pagination
+      Pagination.new(@j.to_h["meta"].to_h["pagination"], nil, nil)
+    end
+
+    def each(&block)
+      @cb.call(@j).each do |member|
+        block.call(member)
+      end
+    end
+
+  end
+end

--- a/lib/hcloud/multi_reply.rb
+++ b/lib/hcloud/multi_reply.rb
@@ -9,7 +9,7 @@ module Hcloud
     end
 
     def pagination
-      @pagination || Pagination.new(@j.to_h["meta"].to_h["pagination"], nil, nil)
+      @pagination || Pagination.new(@j.first.to_h["meta"].to_h["pagination"], nil, nil)
     end
 
     def each(&block)

--- a/lib/hcloud/multi_reply.rb
+++ b/lib/hcloud/multi_reply.rb
@@ -3,12 +3,13 @@ module Hcloud
     include Enumerable
     attr_accessor :cb
 
-    def initialize(j:)
+    def initialize(j:, pagination: nil)
        @j = j
+       @pagination = pagination
     end
 
     def pagination
-      Pagination.new(@j.to_h["meta"].to_h["pagination"], nil, nil)
+      @pagination || Pagination.new(@j.to_h["meta"].to_h["pagination"], nil, nil)
     end
 
     def each(&block)

--- a/lib/hcloud/pagination.rb
+++ b/lib/hcloud/pagination.rb
@@ -1,0 +1,14 @@
+module Hcloud
+  class Pagination
+    Attributes = {
+      page: nil,
+      per_page: nil,
+      previous_page: nil,
+      next_page: nil,
+      last_page: nil,
+      total_entries: nil,
+    }
+    
+    include EntryLoader
+  end
+end

--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -1,7 +1,5 @@
 module Hcloud
   class ServerResource < AbstractResource
-    include Enumerable
-
     def create(name:,
                server_type:,
                datacenter: nil,
@@ -23,8 +21,8 @@ module Hcloud
     end
 
     def all
-      Oj.load(request("servers").run.body)["servers"].map do |x|
-        Server.new(x, self, client)
+      mj("servers") do |j|
+        j.flat_map{|x| x["servers"].map{ |x| Server.new(x, self, client) } }
       end
     end
 

--- a/lib/hcloud/ssh_key_resource.rb
+++ b/lib/hcloud/ssh_key_resource.rb
@@ -1,10 +1,9 @@
 module Hcloud
   class SSHKeyResource < AbstractResource
-    include Enumerable
-
     def all
-      j = Oj.load(request("ssh_keys").run.body)
-      j["ssh_keys"].map{|x| SSHKey.new(x, self, client) }
+      mj("ssh_keys") do |j|
+        j.flat_map{|x| x["ssh_keys"].map{ |x| SSHKey.new(x, self, client) } }
+      end
     end
 
     def create(name:, public_key:)

--- a/spec/fake_service/action.rb
+++ b/spec/fake_service/action.rb
@@ -48,11 +48,13 @@ module Hcloud
         
         params do
           optional :status, type: String
+          optional :per_page, type: Integer
+          optional :page, type: Integer
         end
         get do
           dc = $ACTIONS.deep_dup
           dc["actions"].select!{|x| x["status"].to_s == params[:status].to_s } if !params[:status].nil?
-          dc
+          FakeService.pagination_wrapper(dc, "actions", params[:per_page], params[:page])
         end
       end
     end

--- a/spec/fake_service/action.rb
+++ b/spec/fake_service/action.rb
@@ -50,10 +50,16 @@ module Hcloud
           optional :status, type: String
           optional :per_page, type: Integer
           optional :page, type: Integer
+          optional :sort, type: String
         end
         get do
           dc = $ACTIONS.deep_dup
           dc["actions"].select!{|x| x["status"].to_s == params[:status].to_s } if !params[:status].nil?
+          dc["actions"].shuffle!
+          if !params[:sort].nil?
+            dc["actions"].sort_by!{|x| x[params[:sort].split(":")[0]] }
+            dc["actions"].reverse! if params[:sort].end_with?(":desc")
+          end
           FakeService.pagination_wrapper(dc, "actions", params[:per_page], params[:page])
         end
       end

--- a/spec/fake_service/base.rb
+++ b/spec/fake_service/base.rb
@@ -2,6 +2,30 @@ require 'grape'
 
 module Hcloud
   module FakeService
+
+    def self.pagination_wrapper(object, key, per_page, page)
+      o = object.deep_dup
+      per_page ||= 25
+      page ||= 1
+      per_page = 50 if per_page > 50
+      per_page = 25 if per_page < 1
+      age = 1 if page < 1
+      low = per_page*(page-1)
+      high = per_page*page
+      last_page = (o[key].size / per_page) + ((o[key].size % per_page).zero? ? 0 : 1)
+      o["meta"] ||= {}
+      o["meta"]["pagination"] = {
+        "page" => page,
+        "per_page" => per_page,
+        "previous_page" => page > 1 ? page - 1 : nil,
+        "next_page" => page < last_page ? page + 1 : nil,
+        "last_page" => last_page,
+        "total_entries" => o[key].size 
+      }
+      o[key] = o[key][low...high].to_a
+      o
+    end
+
     class Base < Grape::API
       version "v1", using: :path
 

--- a/spec/fake_service/server.rb
+++ b/spec/fake_service/server.rb
@@ -51,6 +51,7 @@ module Hcloud
 
             params do
               optional :status, type: String
+              optional :sort, type: String
             end
             get do
               dc = $ACTIONS.deep_dup
@@ -58,6 +59,11 @@ module Hcloud
                 x["resources"].to_a.any? do |y| 
                   y.to_h["type"] == "server" and y.to_h["id"].to_s == @x["id"].to_s
                 end
+              end
+              dc["actions"].shuffle!
+              if !params[:sort].nil?
+                dc["actions"].sort_by!{|x| x[params[:sort].split(":")[0]] }
+                dc["actions"].reverse! if params[:sort].end_with?(":desc")
               end
               if !params[:status].nil?
                 dc["actions"].select! do |x| 

--- a/spec/fake_service/server.rb
+++ b/spec/fake_service/server.rb
@@ -60,11 +60,6 @@ module Hcloud
                   y.to_h["type"] == "server" and y.to_h["id"].to_s == @x["id"].to_s
                 end
               end
-              dc["actions"].shuffle!
-              if !params[:sort].nil?
-                dc["actions"].sort_by!{|x| x[params[:sort].split(":")[0]] }
-                dc["actions"].reverse! if params[:sort].end_with?(":desc")
-              end
               if !params[:status].nil?
                 dc["actions"].select! do |x| 
                   x["status"].to_s == params[:status].to_s

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -131,6 +131,7 @@ describe "Server" do
     expect(client.actions.order(:id).map(&:id)).to eq([1,2,3])
     expect(client.actions.order(id: :asc).map(&:id)).to eq([1,2,3])
     expect(client.actions.order(id: :desc).map(&:id)).to eq([3,2,1])
+    expect{client.actions.order(1).map(&:id)}.to raise_error(ArgumentError)
     expect(client.actions.per_page(1).page(1).all.pagination.total_entries).to eq(3)
     expect(client.actions.per_page(1).page(1).all.pagination.last_page).to eq(3)
     expect(client.actions.per_page(1).page(1).all.pagination.next_page).to eq(2)

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -68,6 +68,8 @@ describe "Server" do
     expect do
       action, server, pass = client.servers.create(name: "moo", server_type: "cx11", image: 1)
     end.not_to(raise_error)
+    expect(client.actions.per_page(1).page(1).count).to eq(1)
+    expect(client.actions.per_page(1).page(2).count).to eq(0)
     expect(server.id).to be_a Integer
     expect(server.name).to eq("moo")
     expect(server.rescue_enabled).to be false
@@ -125,6 +127,9 @@ describe "Server" do
     expect(client.actions.per_page(2).page(2).where(status: "running").count).to eq(1)
     expect(client.actions.per_page(2).page(2).count).to eq(1)
     expect(client.actions.per_page(2).page(1).count).to eq(2)
+    expect(client.actions.order(:id).map(&:id)).to eq([1,2,3])
+    expect(client.actions.order(id: :asc).map(&:id)).to eq([1,2,3])
+    expect(client.actions.order(id: :desc).map(&:id)).to eq([3,2,1])
     expect(client.actions.per_page(1).page(1).all.pagination.total_entries).to eq(3)
     expect(client.actions.per_page(1).page(1).all.pagination.last_page).to eq(3)
     expect(client.actions.per_page(1).page(1).all.pagination.next_page).to eq(2)

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -69,6 +69,7 @@ describe "Server" do
       action, server, pass = client.servers.create(name: "moo", server_type: "cx11", image: 1)
     end.not_to(raise_error)
     expect(client.actions.per_page(1).page(1).count).to eq(1)
+    expect(aclient.actions.count).to eq(1)
     expect(client.actions.per_page(1).page(2).count).to eq(0)
     expect(server.id).to be_a Integer
     expect(server.name).to eq("moo")
@@ -141,6 +142,8 @@ describe "Server" do
     expect(client.actions.per_page(10).page(3).count).to eq(0)
     expect(aclient.actions.count).to eq(3)
     expect(aclient.actions.limit(2).count).to eq(2)
+    expect(aclient.actions.limit(3).count).to eq(3)
+    expect(aclient.actions.limit(4).count).to eq(3)
     expect(aclient.actions.all.pagination).to eq(:auto)
     sleep(0.6)
     expect(client.servers.none?{|x| x.status == "initalizing"}).to be true

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -10,6 +10,12 @@ describe "Server" do
     Hcloud::Client.const_set(:MAX_ENTRIES_PER_PAGE, 1)
     Hcloud::Client.new(token: "secure", auto_pagination: true)
   end
+  
+  let :bclient do
+    Hcloud::Client.send(:remove_const, :MAX_ENTRIES_PER_PAGE)
+    Hcloud::Client.const_set(:MAX_ENTRIES_PER_PAGE, 2)
+    Hcloud::Client.new(token: "secure", auto_pagination: true)
+  end
 
   it "fetch server" do
     expect(client.servers.count).to eq(0)
@@ -97,6 +103,7 @@ describe "Server" do
         name: "foo", server_type: "cx11", image: 1, datacenter: 2,
       )
     end.not_to(raise_error)
+    expect(bclient.actions.count).to eq(2)
     expect(server.id).to be_a Integer
     expect(server.datacenter.id).to eq(2)
     expect(action.status).to eq("running")

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -99,11 +99,12 @@ describe "Server" do
   it "create new server, custom datacenter" do
     action, server, pass = nil
     expect do
-      action, server, pass = client.servers.create(
+      action, server, pass = bclient.servers.create(
         name: "foo", server_type: "cx11", image: 1, datacenter: 2,
       )
     end.not_to(raise_error)
     expect(bclient.actions.count).to eq(2)
+    expect(server.actions.count).to eq(1)
     expect(server.id).to be_a Integer
     expect(server.datacenter.id).to eq(2)
     expect(action.status).to eq("running")


### PR DESCRIPTION
Introduce a MultiReply handler whicht will returns an #Enum to
transpantly iterate over items, but also provides access to pagination
metadata. (ActionResource is currently updated.)

Add #page, #per_page and #order proxyable methods which needs to be
called before invocation. The AbstractResouce will implement this and
distributes them directly to descendants.

I'm not quite clear about it. Generally I'l like to provide a
transparent or at least moderate effort solution for handling concurrent
request. Ideally run every action easily in parallel.