### PR TITLE
Floating IP context

### DIFF
--- a/lib/hcloud/floating_ip.rb
+++ b/lib/hcloud/floating_ip.rb
@@ -6,6 +6,7 @@ module Hcloud
       ip: nil,
       type: nil,
       dns_ptr: nil,
+      server: nil,
       home_location: Location,
       blocked: nil,
     }

--- a/lib/hcloud/floating_ip_resource.rb
+++ b/lib/hcloud/floating_ip_resource.rb
@@ -14,7 +14,7 @@ module Hcloud
       end
       j = Oj.load(request("floating_ips", j: query, code: 200).run.body)
       [
-        Action.new(j["action"], self, client),
+        j.key?("action") ? Action.new(j["action"], self, client) : nil,
         FloatingIP.new(j["floating_ip"], self, client),
       ]
     end


### PR DESCRIPTION
If you create a floating ip without providing a server, there is no action returned, which currently results in an `NoMethodError` exception. Also the floating ip object misses a server attribute.