### PR TITLE
WIP: Intruduce a promise/future object handling

### DIFF
--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/object/to_query'
 module Hcloud
   autoload :Error, 'hcloud/errors'
   autoload :Client, 'hcloud/client'
+  autoload :Future, 'hcloud/future'
   autoload :AbstractResource, 'hcloud/abstract_resource'
   autoload :MultiReply, 'hcloud/multi_reply'
   autoload :ServerResource, 'hcloud/server_resource'

--- a/lib/hcloud/abstract_resource.rb
+++ b/lib/hcloud/abstract_resource.rb
@@ -88,6 +88,10 @@ module Hcloud
     def request(*args)
       client.request(*args)
     end
+    
+    def response(*args)
+      client.response(*args)
+    end
 
     def __entries__(path, **o)
       ret = Oj.load(request(path, o.merge(ep: ep(per_page: 1, page: 1))).run.body)

--- a/lib/hcloud/future.rb
+++ b/lib/hcloud/future.rb
@@ -1,0 +1,17 @@
+module Hcloud
+  class Future < Delegator
+    class << self
+      alias [] new
+    end
+    def initialize(target_class)
+      @target_class = target_class
+    end
+    def __getobj__
+      @obj
+    end
+    def __setobj__(obj)
+      raise "Unexpected target class" if obj.is_a?(@target_class)
+      @obj = obj
+    end
+  end
+end

--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -12,12 +12,16 @@ module Hcloud
       method(:create).parameters.inject(query) do |r, x|
         (var = eval(x.last.to_s)).nil? ? r : r.merge!(x.last => var)
       end
-      j = Oj.load(request('servers', j: query, code: 200).run.body)
-      [
-        Action.new(j['action'], self, client),
-        Server.new(j['server'], self, client),
-        j['root_password']
-      ]
+      response(
+        request('servers', j: query, code: 200), 
+        future: [Future[Action], Future[Server], Future[String]]
+      ) do |ret|
+        [
+          Action.new(j['action'], self, client),
+          Server.new(j['server'], self, client),
+          j['root_password']
+        ]
+      end
     end
 
     def all


### PR DESCRIPTION
Introduce a transparent promise handling to enable concurrent actions. In general this should looks like the following snippet:

```ruby
c = Hcloud::Client.new(token: ...)

# sequentiell
servers = []
3.times do
  _, server, _ = c.server.create(...)
  servers << server # Hcloud::Server instance
end
servers #=> Array of Hcloud::Server

# concurrent
servers = []
c.multi do
  3.times do
    _, server, _ = c.server.create(...)
    servers << server # Hcloud::Future instance
  end
end
servers #=> Array of Hcloud::Server
```