### PR TITLE
fix typo in exception name ResourceUnavailable

### DIFF
--- a/lib/hcloud/errors.rb
+++ b/lib/hcloud/errors.rb
@@ -9,7 +9,7 @@ module Hcloud
     class Locked < Error; end
     class NotFound < Error; end
     class RateLimitExceeded < Error; end
-    class ResourceUnavilable < Error; end
+    class ResourceUnavailable < Error; end
     class ServiceError < Error; end
     class UniquenessError < Error; end
     class UnknownError < Error; end


### PR DESCRIPTION
There's a typo in the exception name `ResourceUnavailable` (`ResourceUnavilable`).

It is used in `lib/hcloud/typhoeus_ext.rb:54` with the correctly spelled name `ResourceUnavailable`, though. This mismatch of names leads to the following ruby runtime error when resource unavailable actually happens:

> uninitialized constant Hcloud::Error::ResourceUnavailable (NameError)
> Did you mean?  Hcloud::Error::ResourceUnavilable