### PR TITLE
Implement firewall support

### DIFF
--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -36,6 +36,9 @@ module Hcloud
   autoload :Network, 'hcloud/network'
   autoload :NetworkResource, 'hcloud/network_resource'
 
+  autoload :Firewall, 'hcloud/firewall'
+  autoload :FirewallResource, 'hcloud/firewall_resource'
+
   autoload :Volume, 'hcloud/volume'
   autoload :VolumeResource, 'hcloud/volume_resource'
 

--- a/lib/hcloud/client.rb
+++ b/lib/hcloud/client.rb
@@ -94,6 +94,10 @@ module Hcloud
       NetworkResource.new(client: self)
     end
 
+    def firewalls
+      FirewallResource.new(client: self)
+    end
+
     def volumes
       VolumeResource.new(client: self)
     end

--- a/lib/hcloud/firewall.rb
+++ b/lib/hcloud/firewall.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hcloud
+  class Firewall
+    require 'hcloud/firewall_resource'
+
+    include EntryLoader
+
+    updatable :name
+    destructible
+
+    has_actions
+
+    def set_rules(rules:) # rubocop:disable Naming/AccessorMethodName
+      prepare_request('actions/set_rules', j: COLLECT_ARGS.call(__method__, binding))
+    end
+
+    def apply_to_resources(apply_to:)
+      prepare_request('actions/apply_to_resources', j: COLLECT_ARGS.call(__method__, binding))
+    end
+
+    def remove_from_resources(remove_from:)
+      prepare_request('actions/remove_from_resources', j: COLLECT_ARGS.call(__method__, binding))
+    end
+  end
+end

--- a/lib/hcloud/firewall_resource.rb
+++ b/lib/hcloud/firewall_resource.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Hcloud
+  class FirewallResource < AbstractResource
+    filter_attributes :name
+
+    def [](arg)
+      case arg
+      when Integer then find_by(id: arg)
+      when String then find_by(name: arg)
+      end
+    end
+
+    def create(name:, rules: [], apply_to: [])
+      prepare_request(
+        'firewalls', j: COLLECT_ARGS.call(__method__, binding),
+                     expected_code: 201
+      ) do |response|
+        Firewall.new(client, response.parsed_json[:firewall])
+      end
+    end
+  end
+end

--- a/spec/fake_service/base.rb
+++ b/spec/fake_service/base.rb
@@ -49,6 +49,7 @@ module Hcloud
       require_relative './ssh_key'
       require_relative './location'
       require_relative './datacenter'
+      require_relative './firewall'
       require_relative './network'
 
       mount Action
@@ -60,6 +61,7 @@ module Hcloud
       mount Datacenter
       mount Location
       mount SSHKey
+      mount Firewall
       mount Network
     end
   end

--- a/spec/fake_service/firewall.rb
+++ b/spec/fake_service/firewall.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Hcloud
+  module FakeService
+    $FIREWALL_ID = 0
+    $FIREWALLS = {
+      'firewalls' => [],
+      'meta' => {
+        'pagination' => {
+          'page' => 1,
+          'per_page' => 25,
+          'previous_page' => nil,
+          'next_page' => nil,
+          'last_page' => 1,
+          'total_entries' => 2
+        }
+      }
+    }
+
+    class Firewall < Grape::API
+      group :firewalls do
+        params do
+          requires :id, type: Integer
+        end
+        route_param :id do
+          before_validation do
+            @x = $FIREWALLS['firewalls'].find { |x| x['id'].to_s == params[:id].to_s }
+            error!({ error: { code: :not_found } }, 404) if @x.nil?
+          end
+          get do
+            { firewall: @x }
+          end
+
+          group :actions do
+            params do
+              requires :aid, type: Integer
+            end
+            route_param :aid do
+              before_validation do
+                @a = Action.resource_action('firewall', @x['id'], params[:aid])
+                error!({ error: { code: :not_found } }, 404) if @a.nil?
+              end
+              get do
+                { action: @a }
+              end
+            end
+
+            params do
+              optional :status, type: String
+              optional :sort, type: String
+            end
+            get do
+              actions = Action.resource_actions('firewall', @x['id'])
+              unless params[:status].nil?
+                actions['actions'].select! do |x|
+                  x['status'].to_s == params[:status].to_s
+                end
+              end
+              actions
+            end
+
+            params do
+              optional :rules, type: Array
+            end
+            post :set_rules do
+              error!({ error: { code: :invalid_input } }, 400) if params[:rules].nil?
+
+              @x['rules'] = params[:rules]
+
+              a = Action.add(command: 'set_rules', status: 'success',
+                             resources: [{ id: @x['id'], type: 'firewall' }])
+              { action: a }
+            end
+
+            params do
+              optional :apply_to, type: Array
+            end
+            post :apply_to_resources do
+              error!({ error: { code: :invalid_input } }, 400) if params[:apply_to].nil?
+
+              @x['applied_to'].concat(params[:apply_to].map(&:to_h))
+
+              a = Action.add(command: 'apply_to_resources', status: 'success',
+                             resources: [{ id: @x['id'], type: 'firewall' }])
+              { action: a }
+            end
+
+            params do
+              optional :remove_from, type: Array
+            end
+            post :remove_from_resources do
+              error!({ error: { code: :invalid_input } }, 400) if params[:remove_from].nil?
+
+              params[:remove_from].each do |remove_from|
+                @x['applied_to'].delete_if do |applied_to|
+                  next unless remove_from['type'] == applied_to['type']
+
+                  case applied_to['type']
+                  when 'server'
+                    remove_from.dig('server', 'id') == applied_to.dig('server', 'id')
+                  when 'label_selector'
+                    remove_from.dig('label_selector', 'selector') \
+                      == applied_to.dig('label_selector', 'selector')
+                  end
+                end
+              end
+
+              a = Action.add(command: 'remove_from_resources', status: 'success',
+                             resources: [{ id: @x['id'], type: 'firewall' }])
+              { action: a }
+            end
+          end
+
+          params do
+            optional :name, type: String
+          end
+          put do
+            error!({ error: { code: :invalid_input } }, 400) if params[:name].nil?
+            @x['name'] = params[:name]
+            { firewall: @x }
+          end
+
+          delete do
+            $FIREWALLS['firewalls'].delete(@x)
+            @body = nil
+            status 204
+          end
+        end
+
+        params do
+          optional :name, type: String
+          optional :rules, type: Array
+          optional :apply_to, type: Array
+        end
+        post do
+          error!({ error: { code: :invalid_input } }, 400) if params[:name].nil?
+
+          if $FIREWALLS['firewalls'].any? { |x| params[:name] == x['name'] }
+            error!({ error: { code: :uniqueness_error } }, 400)
+          end
+
+          firewall = {
+            'id' => $FIREWALL_ID += 1,
+            'name' => params[:name],
+            'applied_to' => params[:apply_to] || [],
+            'rules' => params[:rules] || []
+          }
+          $FIREWALLS['firewalls'] << firewall
+          { firewall: firewall }
+        end
+
+        params do
+          optional :name, type: String
+        end
+        get do
+          if params.key?(:name)
+            firewalls = $FIREWALLS.deep_dup
+            firewalls['firewalls'].select! { |x| x['name'] == params[:name] }
+            firewalls
+          else
+            $FIREWALLS
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/hcloud/firewall_spec.rb
+++ b/spec/hcloud/firewall_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Firewall' do
+  let :client do
+    Hcloud::Client.new(token: 'secure')
+  end
+
+  it 'fetch firewalls' do
+    expect(client.firewalls.count).to eq(0)
+  end
+
+  it 'create new firewall, handle missing name' do
+    expect { client.firewalls.create(name: nil) }.to(
+      raise_error(Hcloud::Error::InvalidInput)
+    )
+  end
+
+  it 'create new firewall, only name' do
+    firewall = client.firewalls.create(name: 'fw')
+    expect(firewall).to be_a Hcloud::Firewall
+    expect(firewall.id).to be_a Integer
+    expect(firewall.name).to eq('fw')
+  end
+
+  it 'create new firewall, uniq name' do
+    expect { client.firewalls.create(name: 'fw') }.to(
+      raise_error(Hcloud::Error::UniquenessError)
+    )
+  end
+
+  it 'create new firewall, with rules and apply_to' do
+    rules = [{
+      'protocol' => 'tcp',
+      'source_ips' => ['192.0.2.0/24'],
+      'port' => 80,
+      'direction' => 'in',
+      'description' => 'HTTP access'
+    }]
+    apply_to = [{
+      'server' => {
+        'id' => 1
+      },
+      'type' => 'server'
+    }]
+    firewall = client.firewalls.create(name: 'fw-rules', rules: rules, apply_to: apply_to)
+    expect(firewall).to be_a Hcloud::Firewall
+    expect(firewall.id).to be_a Integer
+    expect(firewall.name).to eq('fw-rules')
+    expect(firewall.rules.length).to eq(1)
+    expect(firewall.rules[0]['protocol']).to eq('tcp')
+    expect(firewall.rules[0]['source_ips']).to eq(['192.0.2.0/24'])
+    expect(firewall.rules[0]['port']).to eq(80)
+    expect(firewall.rules[0]['direction']).to eq('in')
+    expect(firewall.rules[0]['description']).to eq('HTTP access')
+    expect(firewall.applied_to.length).to eq(1)
+    expect(firewall.applied_to[0]['server']['id']).to eq(1)
+    expect(firewall.applied_to[0]['type']).to eq('server')
+  end
+
+  it 'fetch firewalls' do
+    expect(client.firewalls.count).to eq(2)
+  end
+
+  it '#[] -> find by id' do
+    expect(client.firewalls.first).to be_a Hcloud::Firewall
+    id = client.firewalls.first.id
+    expect(id).to be_a Integer
+    expect(client.firewalls[id]).to be_a Hcloud::Firewall
+  end
+
+  it '#[] -> find by id, handle nonexistent' do
+    expect(client.firewalls[0]).to be nil
+  end
+
+  it '#find -> find by id' do
+    expect(client.firewalls.first).to be_a Hcloud::Firewall
+    id = client.firewalls.first.id
+    expect(id).to be_a Integer
+    expect(client.firewalls.find(id)).to be_a Hcloud::Firewall
+  end
+
+  it '#find -> find by id, handle nonexistent' do
+    expect { client.firewalls.find(0).id }.to raise_error(Hcloud::Error::NotFound)
+  end
+
+  it '#[] -> filter by name' do
+    expect(client.firewalls['fw']).to be_a Hcloud::Firewall
+    expect(client.firewalls['fw'].name).to eq('fw')
+    expect(client.firewalls['fw'].rules.length).to eq(0)
+  end
+
+  it '#[] -> filter by name, handle nonexistent' do
+    expect(client.firewalls['fw-missing']).to be nil
+  end
+
+  it '#set_rules' do
+    rules = [{
+      'protocol' => 'tcp',
+      'source_ips' => ['192.0.2.0/30'],
+      'port' => 21,
+      'direction' => 'in',
+      'description' => 'FTP access'
+    }]
+    action = client.firewalls['fw'].set_rules(rules: rules)
+
+    expect(client.firewalls['fw'].rules.length).to eq(1)
+    expect(client.firewalls['fw'].rules[0][:protocol]).to eq('tcp')
+    expect(client.firewalls['fw'].rules[0][:source_ips]).to eq(['192.0.2.0/30'])
+    expect(client.firewalls['fw'].rules[0][:port]).to eq(21)
+    expect(client.firewalls['fw'].rules[0][:direction]).to eq('in')
+    expect(client.firewalls['fw'].rules[0][:description]).to eq('FTP access')
+
+    expect(client.actions.count).to eq(1)
+    expect(client.firewalls['fw'].actions.count).to eq(1)
+    expect(action.command).to eq('set_rules')
+  end
+
+  it '#set_rules, missing rules' do
+    expect { client.firewalls['fw'].set_rules(rules: nil) }.to(
+      raise_error(Hcloud::Error::InvalidInput)
+    )
+  end
+
+  it '#apply_to_resources' do
+    apply_to = [{
+      'server' => {
+        'id' => 42
+      },
+      'type' => 'server'
+    }, {
+      'server' => {
+        'id' => 1
+      },
+      'type' => 'server'
+    }]
+    action = client.firewalls['fw'].apply_to_resources(apply_to: apply_to)
+
+    expect(client.firewalls['fw'].applied_to.length).to eq(2)
+    expect(client.firewalls['fw'].applied_to.map { |res| res[:server][:id] }).to eq([42, 1])
+
+    expect(client.actions.count).to eq(2)
+    expect(client.firewalls['fw'].actions.count).to eq(2)
+    expect(action.command).to eq('apply_to_resources')
+  end
+
+  it '#apply_to_resources, missing apply_to' do
+    expect { client.firewalls['fw'].apply_to_resources(apply_to: nil) }.to(
+      raise_error(Hcloud::Error::InvalidInput)
+    )
+  end
+
+  it '#remove_from_resources' do
+    remove_from = [{
+      'server' => {
+        'id' => 1
+      },
+      'type' => 'server'
+    }]
+    action = client.firewalls['fw'].remove_from_resources(remove_from: remove_from)
+
+    expect(client.firewalls['fw'].applied_to.length).to eq(1)
+    expect(client.firewalls['fw'].applied_to[0][:server][:id]).to eq(42)
+
+    expect(client.actions.count).to eq(3)
+    expect(client.firewalls['fw'].actions.count).to eq(3)
+    expect(action.command).to eq('remove_from_resources')
+  end
+
+  it '#remove_from_resources, missing remove_from' do
+    expect { client.firewalls['fw'].remove_from_resources(remove_from: nil) }.to(
+      raise_error(Hcloud::Error::InvalidInput)
+    )
+  end
+
+  it '#update' do
+    id = client.firewalls['fw'].id
+    expect(id).to be_a Integer
+    expect(client.firewalls.find(id).name).to eq('fw')
+    expect(client.firewalls.find(id).update(name: 'firewall').name).to eq('firewall')
+    expect(client.firewalls.find(id).name).to eq('firewall')
+  end
+
+  it '#destroy' do
+    expect(client.firewalls.first).to be_a Hcloud::Firewall
+    id = client.firewalls.first.id
+    expect(id).to be_a Integer
+    expect(client.firewalls.find(id).destroy).to be_a Hcloud::Firewall
+    expect(client.firewalls[id]).to be nil
+  end
+end


### PR DESCRIPTION
This PR implements support for firewalls, cf. #25 

- [x] Base firewall API calls
- [x] Firewall actions
- [x] Access to action history for a single firewall (`firewall.actions`, endpoints `/firewalls/{id}/actions` and `/firewalls/{id}/actions/{action_id}`)