### PR TITLE
fix rubocop linting warnings

### DIFF
--- a/spec/hcloud/network_spec.rb
+++ b/spec/hcloud/network_spec.rb
@@ -95,7 +95,7 @@ describe 'Network' do
     network = client.networks['testnet']
     expect(network).to be_a Hcloud::Network
 
-    subnet = network.add_subnet(
+    network.add_subnet(
       type: 'cloud',
       network_zone: 'eu-central',
       ip_range: '192.168.1.0/24'


### PR DESCRIPTION
Fixes the linter warnings output by `bundle exec rubocop` (which should be what's running in Github actions)