### PR TITLE
Label support

### DIFF
--- a/lib/hcloud/entry_loader.rb
+++ b/lib/hcloud/entry_loader.rb
@@ -68,6 +68,34 @@ module Hcloud
         end
       end
 
+      def has_labels # rubocop:disable Naming/PredicateName
+        define_method(:add_label) do |label, value = nil|
+          add_labels({ label => value })
+        end
+
+        define_method(:add_labels) do |labels|
+          labels.each do |label, value|
+            self.labels[label.to_s] = value.to_s
+          end
+
+          update(labels: self.labels)
+          self.labels
+        end
+
+        define_method(:remove_label) do |label|
+          remove_labels([label])
+        end
+
+        define_method(:remove_labels) do |labels|
+          labels.each do |label|
+            self.labels.delete(label.to_s)
+          end
+
+          update(labels: self.labels)
+          self.labels
+        end
+      end
+
       def resource_class
         ancestors.reverse.find { |const| const.include?(Hcloud::EntryLoader) }
       end

--- a/lib/hcloud/floating_ip_resource.rb
+++ b/lib/hcloud/floating_ip_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class FloatingIPResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     bind_to FloatingIP
 
@@ -13,7 +13,7 @@ module Hcloud
       end
     end
 
-    def create(type:, server: nil, home_location: nil, description: nil)
+    def create(type:, server: nil, home_location: nil, description: nil, labels: {})
       prepare_request(
         'floating_ips', j: COLLECT_ARGS.call(__method__, binding),
                         expected_code: 201

--- a/lib/hcloud/image_resource.rb
+++ b/lib/hcloud/image_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class ImageResource < AbstractResource
-    filter_attributes :type, :bound_to, :name
+    filter_attributes :type, :bound_to, :name, :label_selector
 
     bind_to Image
 

--- a/lib/hcloud/network_resource.rb
+++ b/lib/hcloud/network_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class NetworkResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     bind_to Network
 
@@ -13,7 +13,7 @@ module Hcloud
       end
     end
 
-    def create(name:, ip_range:, subnets: nil, routes: nil)
+    def create(name:, ip_range:, subnets: nil, routes: nil, labels: {})
       prepare_request(
         'networks', j: COLLECT_ARGS.call(__method__, binding),
                     expected_code: 201

--- a/lib/hcloud/server.rb
+++ b/lib/hcloud/server.rb
@@ -21,6 +21,7 @@ module Hcloud
     destructible
 
     has_actions
+    has_labels
 
     def enable_rescue(type: 'linux64', ssh_keys: [])
       query = COLLECT_ARGS.call(__method__, binding)

--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class ServerResource < AbstractResource
-    filter_attributes :status, :name
+    filter_attributes :status, :name, :label_selector
 
     bind_to Server
 
@@ -13,7 +13,8 @@ module Hcloud
                start_after_create: nil,
                ssh_keys: [],
                networks: [],
-               user_data: nil)
+               user_data: nil,
+               labels: {})
       prepare_request('servers', j: COLLECT_ARGS.call(__method__, binding),
                                  expected_code: 201) do |response|
         [

--- a/lib/hcloud/ssh_key.rb
+++ b/lib/hcloud/ssh_key.rb
@@ -8,5 +8,7 @@ module Hcloud
 
     updatable :name
     destructible
+
+    has_labels
   end
 end

--- a/lib/hcloud/ssh_key_resource.rb
+++ b/lib/hcloud/ssh_key_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class SSHKeyResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     def [](arg)
       case arg
@@ -11,7 +11,7 @@ module Hcloud
       end
     end
 
-    def create(name:, public_key:)
+    def create(name:, public_key:, labels: {})
       prepare_request(
         'ssh_keys', j: COLLECT_ARGS.call(__method__, binding),
                     expected_code: 201

--- a/lib/hcloud/volume_resource.rb
+++ b/lib/hcloud/volume_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class VolumeResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     def [](arg)
       case arg
@@ -11,7 +11,7 @@ module Hcloud
       end
     end
 
-    def create(size:, name:, automount: nil, format: nil, location: nil, server: nil)
+    def create(size:, name:, automount: nil, format: nil, location: nil, server: nil, labels: {})
       prepare_request(
         'volumes', j: COLLECT_ARGS.call(__method__, binding),
                    expected_code: 201

--- a/spec/fake_service/base.rb
+++ b/spec/fake_service/base.rb
@@ -29,6 +29,20 @@ module Hcloud
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+    def self.label_selector_matches(label_selector, resource_labels)
+      resource_labels ||= {}
+
+      # only implements a subset of the label selector query language
+      # to support selectors like "key=value,key2"
+      selectors = label_selector.split(',')
+      selectors.all? do |selector|
+        key, value = selector.split('=', 2)
+        value = '' if value.nil? # API uses "" to denote labels without values
+
+        resource_labels.key?(key) && resource_labels[key] == value
+      end
+    end
+
     class Base < Grape::API
       version 'v1', using: :path
 

--- a/spec/fake_service/image.rb
+++ b/spec/fake_service/image.rb
@@ -92,6 +92,7 @@ module Hcloud
             end
             @x['description'] = params[:description] unless params[:description].nil?
             @x['type'] = params[:type] unless params[:type].nil?
+            @x['labels'] = params[:labels] unless params[:labels].nil?
             { image: @x }
           end
 
@@ -143,6 +144,11 @@ module Hcloud
           dc['images'].select! { |x| x['type'] == params[:type] } if params[:type]&.size&.positive?
           unless params[:bound_to].nil?
             dc['images'].select! { |x| x['bound_to'].to_s == params[:bound_to].to_s }
+          end
+          unless params[:label_selector].nil?
+            dc['images'].select! do |x|
+              FakeService.label_selector_matches(params[:label_selector], x['labels'])
+            end
           end
           dc
         end

--- a/spec/hcloud/network_spec.rb
+++ b/spec/hcloud/network_spec.rb
@@ -35,7 +35,8 @@ describe 'Network' do
         ip_range: '192.168.0.0/24',
         network_zone: 'eu-central',
         type: 'cloud'
-      }]
+      }],
+      labels: { 'source' => 'create' }
     )
     expect(network).to be_a Hcloud::Network
     expect(network.id).to be_a Integer
@@ -45,6 +46,7 @@ describe 'Network' do
     expect(network.subnets[0][:ip_range]).to eq('192.168.0.0/24')
     expect(network.subnets[0][:network_zone]).to eq('eu-central')
     expect(network.subnets[0][:type]).to eq('cloud')
+    expect(network.labels).to eq({ 'source' => 'create' })
   end
 
   it 'create new network, uniq name' do
@@ -142,12 +144,26 @@ describe 'Network' do
     expect(client.networks['testnet'].actions.count).to eq(4)
   end
 
-  it '#update' do
+  it '#update(name:)' do
     id = client.networks['testnet'].id
     expect(id).to be_a Integer
     expect(client.networks.find(id).name).to eq('testnet')
     expect(client.networks.find(id).update(name: 'testing').name).to eq('testing')
     expect(client.networks.find(id).name).to eq('testing')
+  end
+
+  it '#update(labels:)' do
+    id = client.networks.first.id
+    network = client.networks[id]
+    updated = network.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.networks[id].labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    networks = client.networks.where(label_selector: 'source=update').to_a
+    expect(networks.length).to eq(1)
+    expect(networks.first.labels).to include('source' => 'update')
   end
 
   it '#destroy' do

--- a/spec/hcloud/server_legacy_spec.rb
+++ b/spec/hcloud/server_legacy_spec.rb
@@ -82,7 +82,9 @@ describe 'Server' do
   it 'create new server' do
     action, server, pass = nil
     expect do
-      action, server, pass = client.servers.create(name: 'moo', server_type: 'cx11', image: 1)
+      action, server, pass = client.servers.create(
+        name: 'moo', server_type: 'cx11', image: 1, labels: { 'source' => 'test' }
+      )
     end.not_to(raise_error)
     expect(client.actions.per_page(1).page(1).count).to eq(1)
     expect(aclient.actions.count).to eq(1)
@@ -101,6 +103,7 @@ describe 'Server' do
     expect(server.image.id).to eq(1)
     expect(server.status).to eq('initalizing')
     expect(server.image.id).to eq(1)
+    expect(server.labels).to eq({ 'source' => 'test' })
     expect(action.status).to eq('running')
     expect(action.command).to eq('create_server')
     expect(pass).to eq('test123')
@@ -259,6 +262,19 @@ describe 'Server' do
     expect { server = client.servers[1].update(name: 'hui') }.not_to raise_error
     expect(server.name).to eq('hui')
     expect(client.servers.find(1).name).to eq('hui')
+  end
+
+  it '#update(labels:)' do
+    server = client.servers.find(1)
+    updated = server.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.servers.find(1).labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    servers = client.servers.where(label_selector: 'source=update').to_a
+    expect(servers.length).to eq(1)
+    expect(servers.first.labels).to include('source' => 'update')
   end
 
   it '#destroy' do

--- a/spec/hcloud/zz_image_spec.rb
+++ b/spec/hcloud/zz_image_spec.rb
@@ -76,6 +76,19 @@ describe 'Image' do
     )
   end
 
+  it '#update(labels:)' do
+    image = client.images[3454]
+    updated = image.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.images[3454].labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    images = client.images.where(label_selector: 'source=update').to_a
+    expect(images.length).to eq(1)
+    expect(images.first.labels).to include('source' => 'update')
+  end
+
   it '#to_snapshot' do
     expect(client.images[3454].description).to eq('test123')
     expect(client.images[3454].to_snapshot).to be_a Hcloud::Image


### PR DESCRIPTION
Implementing label support for different resources.

Core idea of this PR is to add `has_labels`, which works in the same way as the existing `has_actions`. When added to a resource class it creates additional methods on this class.

The `create` methods of resources with label support receive a new parameter `labels: {}`, setting no labels by default.

To allow to filter resources by labels we add the additional filter attribute `:label_selector`. This allows users to specify `label_selector: 'key=value,key2'` to filter. I think that this is enough for now. Providing a Ruby-native way for label selectors would be too much work, because they are quite powerful (label existence, label non-existence, label value equality, label value inequality, AND conjunction, `in`, `notin`).

If we need a better way, we could add a `LabelSelectorBuilder` or similar later. This class could take Ruby-native input and generate label selector strings.

The bulk of changes are test cases.

Example usage:

```ruby
client = Hcloud::Client.new(token: ENV['HCLOUD_TOKEN'])

# Create an SSH key with labels, one label with a value, one label without
client.ssh_keys.create(
  name: 'keyname', public_key: 'ssh-ed25519 blah', labels: {'creator' => 'username', 'test' => ''}
)

# Update an SSH key's labels; will delete the label "test"
client.ssh_keys["keyname"].update(labels: {'creator' => 'username-new'})

# Pending discussion, see below; add_ and remove_ labels
client.ssh_keys["keyname"].add_labels({'label-without-value' => '', 'one-more-label' => 'some-value'})
client.ssh_keys["keyname"].add_label('label-no-value')
client.ssh_keys["keyname"].add_label('label-with-value', 'my-value')

client.ssh_keys["keyname"].remove_labels(['label-without-value', 'label-with-value'])
client.ssh_keys["keyname"].remove_label('one-more-label')
```