### PR TITLE
set Github Workflow badge for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hcloud
 
-[![Build Status](https://travis-ci.org/tonobo/hcloud-ruby.svg?branch=master)](https://travis-ci.org/tonobo/hcloud-ruby)
+[![Build Status](https://github.com/tonobo/hcloud-ruby/actions/workflows/ruby.yml/badge.svg)](https://github.com/tonobo/hcloud-ruby/actions/workflows/ruby.yml)
 [![codecov](https://codecov.io/gh/tonobo/hcloud-ruby/branch/master/graph/badge.svg)](https://codecov.io/gh/tonobo/hcloud-ruby)
 [![Gem Version](https://badge.fury.io/rb/hcloud.svg)](https://badge.fury.io/rb/hcloud)
 [![Maintainability](https://api.codeclimate.com/v1/badges/aa67f9d590d86845822f/maintainability)](https://codeclimate.com/github/tonobo/hcloud-ruby/maintainability)


### PR DESCRIPTION
This repository does not use Travis CI to run tests, anymore. It's now using Github Actions.

The failing build status in the README caught my eye. You can see the design of Github's workflow badge here:

https://github.com/tonobo/hcloud-ruby/actions/workflows/ruby.yml/badge.svg

[![Build Status](https://github.com/tonobo/hcloud-ruby/actions/workflows/ruby.yml/badge.svg)](https://github.com/tonobo/hcloud-ruby/actions/workflows/ruby.yml)