### PR TITLE
label support (create, update, search)

### DIFF
--- a/lib/hcloud/firewall_resource.rb
+++ b/lib/hcloud/firewall_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class FirewallResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     def [](arg)
       case arg
@@ -11,7 +11,7 @@ module Hcloud
       end
     end
 
-    def create(name:, rules: [], apply_to: [])
+    def create(name:, rules: [], apply_to: [], labels: {})
       prepare_request(
         'firewalls', j: COLLECT_ARGS.call(__method__, binding),
                      expected_code: 201

--- a/lib/hcloud/floating_ip_resource.rb
+++ b/lib/hcloud/floating_ip_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class FloatingIPResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     bind_to FloatingIP
 
@@ -13,7 +13,7 @@ module Hcloud
       end
     end
 
-    def create(type:, server: nil, home_location: nil, description: nil)
+    def create(type:, server: nil, home_location: nil, description: nil, labels: {})
       prepare_request(
         'floating_ips', j: COLLECT_ARGS.call(__method__, binding),
                         expected_code: 201

--- a/lib/hcloud/image_resource.rb
+++ b/lib/hcloud/image_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class ImageResource < AbstractResource
-    filter_attributes :type, :bound_to, :name
+    filter_attributes :type, :bound_to, :name, :label_selector
 
     bind_to Image
 

--- a/lib/hcloud/network_resource.rb
+++ b/lib/hcloud/network_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class NetworkResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     bind_to Network
 
@@ -13,7 +13,7 @@ module Hcloud
       end
     end
 
-    def create(name:, ip_range:, subnets: nil, routes: nil)
+    def create(name:, ip_range:, subnets: nil, routes: nil, labels: {})
       prepare_request(
         'networks', j: COLLECT_ARGS.call(__method__, binding),
                     expected_code: 201

--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class ServerResource < AbstractResource
-    filter_attributes :status, :name
+    filter_attributes :status, :name, :label_selector
 
     bind_to Server
 
@@ -13,7 +13,8 @@ module Hcloud
                start_after_create: nil,
                ssh_keys: [],
                networks: [],
-               user_data: nil)
+               user_data: nil,
+               labels: {})
       prepare_request('servers', j: COLLECT_ARGS.call(__method__, binding),
                                  expected_code: 201) do |response|
         [

--- a/lib/hcloud/ssh_key_resource.rb
+++ b/lib/hcloud/ssh_key_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class SSHKeyResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     def [](arg)
       case arg
@@ -11,7 +11,7 @@ module Hcloud
       end
     end
 
-    def create(name:, public_key:)
+    def create(name:, public_key:, labels: {})
       prepare_request(
         'ssh_keys', j: COLLECT_ARGS.call(__method__, binding),
                     expected_code: 201

--- a/lib/hcloud/volume_resource.rb
+++ b/lib/hcloud/volume_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class VolumeResource < AbstractResource
-    filter_attributes :name
+    filter_attributes :name, :label_selector
 
     def [](arg)
       case arg
@@ -11,7 +11,7 @@ module Hcloud
       end
     end
 
-    def create(size:, name:, automount: nil, format: nil, location: nil, server: nil)
+    def create(size:, name:, automount: nil, format: nil, location: nil, server: nil, labels: {})
       prepare_request(
         'volumes', j: COLLECT_ARGS.call(__method__, binding),
                    expected_code: 201

--- a/spec/fake_service/base.rb
+++ b/spec/fake_service/base.rb
@@ -29,6 +29,20 @@ module Hcloud
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+    def self.label_selector_matches(label_selector, resource_labels)
+      resource_labels ||= {}
+
+      # only implements a subset of the label selector query language
+      # to support selectors like "key=value,key2"
+      selectors = label_selector.split(',')
+      selectors.all? do |selector|
+        key, value = selector.split('=', 2)
+        value = '' if value.nil? # API uses "" to denote labels without values
+
+        resource_labels.key?(key) && resource_labels[key] == value
+      end
+    end
+
     class Base < Grape::API
       version 'v1', using: :path
 

--- a/spec/fake_service/image.rb
+++ b/spec/fake_service/image.rb
@@ -92,6 +92,7 @@ module Hcloud
             end
             @x['description'] = params[:description] unless params[:description].nil?
             @x['type'] = params[:type] unless params[:type].nil?
+            @x['labels'] = params[:labels] unless params[:labels].nil?
             { image: @x }
           end
 
@@ -143,6 +144,11 @@ module Hcloud
           dc['images'].select! { |x| x['type'] == params[:type] } if params[:type]&.size&.positive?
           unless params[:bound_to].nil?
             dc['images'].select! { |x| x['bound_to'].to_s == params[:bound_to].to_s }
+          end
+          unless params[:label_selector].nil?
+            dc['images'].select! do |x|
+              FakeService.label_selector_matches(params[:label_selector], x['labels'])
+            end
           end
           dc
         end

--- a/spec/hcloud/firewall_spec.rb
+++ b/spec/hcloud/firewall_spec.rb
@@ -44,10 +44,16 @@ describe 'Firewall' do
       },
       'type' => 'server'
     }]
-    firewall = client.firewalls.create(name: 'fw-rules', rules: rules, apply_to: apply_to)
+    firewall = client.firewalls.create(
+      name: 'fw-rules',
+      rules: rules,
+      apply_to: apply_to,
+      labels: { 'source' => 'unittest' }
+    )
     expect(firewall).to be_a Hcloud::Firewall
     expect(firewall.id).to be_a Integer
     expect(firewall.name).to eq('fw-rules')
+    expect(firewall.labels).to eq({ 'source' => 'unittest' })
     expect(firewall.rules.length).to eq(1)
     expect(firewall.rules[0]['protocol']).to eq('tcp')
     expect(firewall.rules[0]['source_ips']).to eq(['192.0.2.0/24'])
@@ -174,12 +180,26 @@ describe 'Firewall' do
     )
   end
 
-  it '#update' do
+  it '#update(name:)' do
     id = client.firewalls['fw'].id
     expect(id).to be_a Integer
     expect(client.firewalls.find(id).name).to eq('fw')
     expect(client.firewalls.find(id).update(name: 'firewall').name).to eq('firewall')
     expect(client.firewalls.find(id).name).to eq('firewall')
+  end
+
+  it '#update(labels:)' do
+    id = client.firewalls['firewall'].id
+    firewall = client.firewalls[id]
+    updated = firewall.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.firewalls[id].labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    firewalls = client.firewalls.where(label_selector: 'source=update').to_a
+    expect(firewalls.length).to eq(1)
+    expect(firewalls.first.labels).to include('source' => 'update')
   end
 
   it '#destroy' do

--- a/spec/hcloud/network_spec.rb
+++ b/spec/hcloud/network_spec.rb
@@ -35,7 +35,8 @@ describe 'Network' do
         ip_range: '192.168.0.0/24',
         network_zone: 'eu-central',
         type: 'cloud'
-      }]
+      }],
+      labels: { 'source' => 'create' }
     )
     expect(network).to be_a Hcloud::Network
     expect(network.id).to be_a Integer
@@ -45,6 +46,7 @@ describe 'Network' do
     expect(network.subnets[0][:ip_range]).to eq('192.168.0.0/24')
     expect(network.subnets[0][:network_zone]).to eq('eu-central')
     expect(network.subnets[0][:type]).to eq('cloud')
+    expect(network.labels).to eq({ 'source' => 'create' })
   end
 
   it 'create new network, uniq name' do
@@ -142,12 +144,26 @@ describe 'Network' do
     expect(client.networks['testnet'].actions.count).to eq(4)
   end
 
-  it '#update' do
+  it '#update(name:)' do
     id = client.networks['testnet'].id
     expect(id).to be_a Integer
     expect(client.networks.find(id).name).to eq('testnet')
     expect(client.networks.find(id).update(name: 'testing').name).to eq('testing')
     expect(client.networks.find(id).name).to eq('testing')
+  end
+
+  it '#update(labels:)' do
+    id = client.networks.first.id
+    network = client.networks[id]
+    updated = network.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.networks[id].labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    networks = client.networks.where(label_selector: 'source=update').to_a
+    expect(networks.length).to eq(1)
+    expect(networks.first.labels).to include('source' => 'update')
   end
 
   it '#destroy' do

--- a/spec/hcloud/server_legacy_spec.rb
+++ b/spec/hcloud/server_legacy_spec.rb
@@ -82,7 +82,9 @@ describe 'Server' do
   it 'create new server' do
     action, server, pass = nil
     expect do
-      action, server, pass = client.servers.create(name: 'moo', server_type: 'cx11', image: 1)
+      action, server, pass = client.servers.create(
+        name: 'moo', server_type: 'cx11', image: 1, labels: { 'source' => 'test' }
+      )
     end.not_to(raise_error)
     expect(client.actions.per_page(1).page(1).count).to eq(1)
     expect(aclient.actions.count).to eq(1)
@@ -101,6 +103,7 @@ describe 'Server' do
     expect(server.image.id).to eq(1)
     expect(server.status).to eq('initalizing')
     expect(server.image.id).to eq(1)
+    expect(server.labels).to eq({ 'source' => 'test' })
     expect(action.status).to eq('running')
     expect(action.command).to eq('create_server')
     expect(pass).to eq('test123')
@@ -259,6 +262,19 @@ describe 'Server' do
     expect { server = client.servers[1].update(name: 'hui') }.not_to raise_error
     expect(server.name).to eq('hui')
     expect(client.servers.find(1).name).to eq('hui')
+  end
+
+  it '#update(labels:)' do
+    server = client.servers.find(1)
+    updated = server.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.servers.find(1).labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    servers = client.servers.where(label_selector: 'source=update').to_a
+    expect(servers.length).to eq(1)
+    expect(servers.first.labels).to include('source' => 'update')
   end
 
   it '#destroy' do

--- a/spec/hcloud/ssh_key_spec.rb
+++ b/spec/hcloud/ssh_key_spec.rb
@@ -32,12 +32,13 @@ describe 'SSHKey' do
   end
 
   it 'create new ssh_key' do
-    key = client.ssh_keys.create(name: 'moo', public_key: REAL_KEY)
+    key = client.ssh_keys.create(name: 'moo', public_key: REAL_KEY, labels: { 'source' => 'test' })
     expect(key).to be_a Hcloud::SSHKey
     expect(key.id).to be_a Integer
     expect(key.name).to eq('moo')
     expect(key.fingerprint.split(':').count).to eq(16)
     expect(key.public_key).to eq(REAL_KEY)
+    expect(key.labels).to eq({ 'source' => 'test' })
   end
 
   it 'create new ssh_key, uniq name' do
@@ -100,8 +101,21 @@ describe 'SSHKey' do
     id = client.ssh_keys.first.id
     expect(id).to be_a Integer
     expect(client.ssh_keys.find(id).name).to eq('moo')
-    expect(client.ssh_keys.find(id).update(name: 'hui').name).to eq('hui')
+    updated = client.ssh_keys.find(id).update(
+      name: 'hui',
+      labels: { 'source' => 'unittest' }
+    )
+    expect(updated.name).to eq('hui')
+    expect(updated.labels['source']).to eq('unittest')
+
     expect(client.ssh_keys.find(id).name).to eq('hui')
+    expect(client.ssh_keys.find(id).labels['source']).to eq('unittest')
+  end
+
+  it '#where -> find by label_selector' do
+    ssh_keys = client.ssh_keys.where(label_selector: 'source=unittest').to_a
+    expect(ssh_keys.length).to eq(1)
+    expect(ssh_keys.first.labels).to include('source' => 'unittest')
   end
 
   it '#destroy' do

--- a/spec/hcloud/zz_image_spec.rb
+++ b/spec/hcloud/zz_image_spec.rb
@@ -76,6 +76,19 @@ describe 'Image' do
     )
   end
 
+  it '#update(labels:)' do
+    image = client.images[3454]
+    updated = image.update(labels: { 'source' => 'update' })
+    expect(updated.labels).to eq({ 'source' => 'update' })
+    expect(client.images[3454].labels).to eq({ 'source' => 'update' })
+  end
+
+  it '#where -> find by label_selector' do
+    images = client.images.where(label_selector: 'source=update').to_a
+    expect(images.length).to eq(1)
+    expect(images.first.labels).to include('source' => 'update')
+  end
+
   it '#to_snapshot' do
     expect(client.images[3454].description).to eq('test123')
     expect(client.images[3454].to_snapshot).to be_a Hcloud::Image


### PR DESCRIPTION
Adds label support following the Hetzner Cloud API behaviour. Labels can be specified when a new resource is created and updated with the `update` method of a resource. It is also possible to search for resources with labels with the `label_selector` in `client.X.where` (X being the desired resource type). Labels are supported by servers, firewalls, floating IPs, networks, SSH keys, volumes and images (read-only).