### PR TITLE
fix auto pagination test to always use three pages

### DIFF
--- a/spec/hcloud/action_spec.rb
+++ b/spec/hcloud/action_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hcloud::Action, doubles: :action do
     end
 
     it 'checks auto pagination' do
-      actions = Array.new(Faker::Number.within(range: 100..150)).map { new_action }
+      actions = Array.new(Faker::Number.within(range: 101..150)).map { new_action }
       pages = []
       page_count = []
       stub_collection(:actions, actions) do |request, _page_info|


### PR DESCRIPTION
The auto pagination test allowed 100 to 150 actions and tested that auto pagination worked with 50 items per page. When 100 was randomly chosen, this only required two page calls (+ one setup call), in all other cases three page calls (+ one setup call). The test failed when 100 was chosen, so as a fix we set the range to 101..150.

Fixes #46 