### PR TITLE
handle action array responses for firewall actions

### DIFF
--- a/spec/fake_service/firewall.rb
+++ b/spec/fake_service/firewall.rb
@@ -69,7 +69,7 @@ module Hcloud
 
               a = Action.add(command: 'set_rules', status: 'success',
                              resources: [{ id: @x['id'], type: 'firewall' }])
-              { action: a }
+              { actions: [a] }
             end
 
             params do
@@ -82,7 +82,7 @@ module Hcloud
 
               a = Action.add(command: 'apply_to_resources', status: 'success',
                              resources: [{ id: @x['id'], type: 'firewall' }])
-              { action: a }
+              { actions: [a] }
             end
 
             params do
@@ -107,7 +107,7 @@ module Hcloud
 
               a = Action.add(command: 'remove_from_resources', status: 'success',
                              resources: [{ id: @x['id'], type: 'firewall' }])
-              { action: a }
+              { actions: [a] }
             end
           end
 

--- a/spec/fake_service/server.rb
+++ b/spec/fake_service/server.rb
@@ -146,6 +146,26 @@ module Hcloud
               @x['protection']['rebuild'] = params[:rebuild] unless params[:rebuild].nil?
               a
             end
+
+            params do
+              optional :type, type: String
+              optional :description, type: String
+              optional :labels, type: Hash
+            end
+            post :create_image do
+              # image will not be stored permanently in this fake, we only return
+              # it immediately on the API call. But subsequent calls to /images/ endpoints
+              # will not return the image
+              a = Action.add(command: 'create_image', status: 'running',
+                             resources: [{ id: @x['id'].to_i, type: 'server' }])
+              image = {
+                'id' => 1,
+                'description' => params[:description],
+                'type' => params[:type],
+                'labels' => params[:labels] || {}
+              }
+              { action: a, image: image }
+            end
           end
 
           params do

--- a/spec/hcloud/firewall_spec.rb
+++ b/spec/hcloud/firewall_spec.rb
@@ -103,7 +103,7 @@ describe 'Firewall' do
       'direction' => 'in',
       'description' => 'FTP access'
     }]
-    action = client.firewalls['fw'].set_rules(rules: rules)
+    actions = client.firewalls['fw'].set_rules(rules: rules)
 
     expect(client.firewalls['fw'].rules.length).to eq(1)
     expect(client.firewalls['fw'].rules[0][:protocol]).to eq('tcp')
@@ -114,7 +114,7 @@ describe 'Firewall' do
 
     expect(client.actions.count).to eq(1)
     expect(client.firewalls['fw'].actions.count).to eq(1)
-    expect(action.command).to eq('set_rules')
+    expect(actions[0].command).to eq('set_rules')
   end
 
   it '#set_rules, missing rules' do
@@ -135,14 +135,14 @@ describe 'Firewall' do
       },
       'type' => 'server'
     }]
-    action = client.firewalls['fw'].apply_to_resources(apply_to: apply_to)
+    actions = client.firewalls['fw'].apply_to_resources(apply_to: apply_to)
 
     expect(client.firewalls['fw'].applied_to.length).to eq(2)
     expect(client.firewalls['fw'].applied_to.map { |res| res[:server][:id] }).to eq([42, 1])
 
     expect(client.actions.count).to eq(2)
     expect(client.firewalls['fw'].actions.count).to eq(2)
-    expect(action.command).to eq('apply_to_resources')
+    expect(actions[0].command).to eq('apply_to_resources')
   end
 
   it '#apply_to_resources, missing apply_to' do
@@ -158,14 +158,14 @@ describe 'Firewall' do
       },
       'type' => 'server'
     }]
-    action = client.firewalls['fw'].remove_from_resources(remove_from: remove_from)
+    actions = client.firewalls['fw'].remove_from_resources(remove_from: remove_from)
 
     expect(client.firewalls['fw'].applied_to.length).to eq(1)
     expect(client.firewalls['fw'].applied_to[0][:server][:id]).to eq(42)
 
     expect(client.actions.count).to eq(3)
     expect(client.firewalls['fw'].actions.count).to eq(3)
-    expect(action.command).to eq('remove_from_resources')
+    expect(actions[0].command).to eq('remove_from_resources')
   end
 
   it '#remove_from_resources, missing remove_from' do

--- a/spec/hcloud/server_legacy_spec.rb
+++ b/spec/hcloud/server_legacy_spec.rb
@@ -342,4 +342,12 @@ describe 'Server' do
     expect(client.servers[2].protection).to be_a Hash
     expect(client.servers[2].protection['delete']).to be true
   end
+
+  it '#create_image' do
+    expect(client.servers[2]).to be_a Hcloud::Server
+    action, image = client.servers[2].create_image(description: 'test image', type: 'snapshot')
+    expect(image.description).to eq('test image')
+    expect(image.type).to eq('snapshot')
+    expect(action.command).to eq('create_image')
+  end
 end


### PR DESCRIPTION
Firewall action API endpoints respond with an array of actions. The current code only expects a single action and will fallback to parsing the response as an empty `Firewall` object. With this adjustment we also handle an array in a field `actions` and return an array of `Action` objects to the caller.

cf. [API docs](https://docs.hetzner.cloud/#firewall-actions-apply-to-resources), I also sent some real requests and indeed firewall actions return an array of actions