### PR TITLE
fix: do not interpret leading : in JSON as symbol

### DIFF
--- a/lib/hcloud/typhoeus_ext.rb
+++ b/lib/hcloud/typhoeus_ext.rb
@@ -30,7 +30,7 @@ module Hcloud
     def parsed_json
       return {} if code == 204
 
-      @parsed_json ||= Oj.load(body, symbol_keys: true).tap do |json|
+      @parsed_json ||= Oj.load(body, symbol_keys: true, mode: :compat).tap do |json|
         next unless request.hydra
 
         check_for_error(

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hcloud::Server, doubles: :server do
   it 'create new server, handle invalid name' do
     stub('servers') do |request, _page_info|
       expect(request.options[:method]).to eq(:post)
-      expect(Oj.load(request.options[:body], symbol_keys: true)).to include(
+      expect(Oj.load(request.options[:body], symbol_keys: true, mode: :compat)).to include(
         server_type: 'cx11',
         image: 1,
         name: 'moo_moo'

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -16,7 +16,7 @@ RSpec::Matchers.define :have_body_params do |params|
   private
 
   def body_params(request)
-    Oj.load(request.encoded_body)
+    Oj.load(request.encoded_body, mode: :compat)
   end
 end
 


### PR DESCRIPTION
`Oj.load` without `mode` interprets strings with a leading `:` character as symbols. It drops the first character and uses the rest as a symbol.  The string `"::/0"` for example gets interpreted as `:":/0"`. We need to set `mode: :compat` to avoid this.

Unit tests all run successfully.

Made a short test towards the actual API with this snippet:

```ruby
require 'hcloud'

client = Hcloud::Client.new(token: ENV['HCLOUD_TOKEN'])
params = {
  name: 'moo',
  rules: [{
    protocol: 'tcp',
    port: '443',
    direction: 'in',
    source_ips: ['::/0']
  }],
}
client.firewalls.create(**params)
p client.firewalls['moo'].rules
```

Before the fix this outputs:

```
$ ruby -Ilib test.rb
[{"direction"=>"in", "protocol"=>"tcp", "port"=>"443", "source_ips"=>[:":/0"], "destination_ips"=>[], "description"=>nil}]
```

After the fix this outputs:

```
$ ruby -Ilib test.rb
[{"direction"=>"in", "protocol"=>"tcp", "port"=>"443", "source_ips"=>["::/0"], "destination_ips"=>[], "description"=>nil}
```

Closes #49 