### PR TITLE
fix: return actions info on firewall create

### DIFF
--- a/lib/hcloud/firewall_resource.rb
+++ b/lib/hcloud/firewall_resource.rb
@@ -18,7 +18,12 @@ module Hcloud
         'firewalls', j: COLLECT_ARGS.call(__method__, binding),
                      expected_code: 201
       ) do |response|
-        Firewall.new(client, response.parsed_json[:firewall])
+        [
+          response.parsed_json[:actions].map do |action|
+            Action.new(client, action)
+          end,
+          Firewall.new(client, response.parsed_json[:firewall])
+        ]
       end
     end
   end

--- a/spec/fake_service/firewall.rb
+++ b/spec/fake_service/firewall.rb
@@ -146,8 +146,19 @@ module Hcloud
             'rules' => params[:rules] || [],
             'labels' => params[:labels] || {}
           }
+
+          actions = []
+          unless params[:rules].to_a.empty?
+            actions << Action.add(command: 'set_rules', status: 'running',
+                                  resources: [{ id: firewall['id'], type: 'firewall' }])
+          end
+          unless params[:apply_to].to_a.empty?
+            actions << Action.add(command: 'apply_to_resources', status: 'running',
+                                  resources: [{ id: firewall['id'], type: 'firewall' }])
+          end
+
           $FIREWALLS['firewalls'] << firewall
-          { firewall: firewall }
+          { actions: actions, firewall: firewall }
         end
 
         params do

--- a/spec/hcloud/firewall_spec.rb
+++ b/spec/hcloud/firewall_spec.rb
@@ -39,9 +39,10 @@ describe Hcloud::Firewall, doubles: :firewall do
         params = { name: 'moo' }
         expectation = stub_create(:firewall, params, actions: [])
 
-        # TODO: client.firewalls should return the actions array, too
-        firewall = client.firewalls.create(**params)
+        actions, firewall = client.firewalls.create(**params)
         expect(expectation.times_called).to eq(1)
+
+        expect(actions).to all be_a Hcloud::Action
 
         expect(firewall).to be_a described_class
         expect(firewall.id).to be_a Integer
@@ -81,8 +82,9 @@ describe Hcloud::Firewall, doubles: :firewall do
           ]
         )
 
-        # TODO: client.firewalls should return the actions array, too
-        firewall = client.firewalls.create(**params)
+        actions, firewall = client.firewalls.create(**params)
+        expect(actions).to all be_a Hcloud::Action
+
         expect(firewall).to be_a described_class
         expect(firewall.id).to be_a Integer
         expect(firewall.created).to be_a Time


### PR DESCRIPTION
When a new firewall is created the API returns a list of actions. This list should also be passed to the caller of `client.firewalls.create`.

Closed #54 