### PR TITLE
add missing features to existing resources

### DIFF
--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -11,6 +11,7 @@ module Hcloud
   autoload :TyphoeusExt, 'hcloud/typhoeus_ext'
   autoload :AbstractResource, 'hcloud/abstract_resource'
   autoload :EntryLoader, 'hcloud/entry_loader'
+  autoload :ResourceLoader, 'hcloud/resource_loader'
 
   autoload :Server, 'hcloud/server'
   autoload :ServerResource, 'hcloud/server_resource'

--- a/lib/hcloud/floating_ip.rb
+++ b/lib/hcloud/floating_ip.rb
@@ -12,7 +12,7 @@ module Hcloud
     )
 
     protectable :delete
-    updatable :description
+    updatable :name, :description
     destructible
 
     has_actions

--- a/lib/hcloud/floating_ip_resource.rb
+++ b/lib/hcloud/floating_ip_resource.rb
@@ -13,7 +13,7 @@ module Hcloud
       end
     end
 
-    def create(type:, server: nil, home_location: nil, description: nil, labels: {})
+    def create(type:, name: nil, server: nil, home_location: nil, description: nil, labels: {})
       raise Hcloud::Error::InvalidInput, 'no type given' if type.blank?
       if server.nil? && home_location.nil?
         raise Hcloud::Error::InvalidInput, 'either server or home_location must be given'

--- a/lib/hcloud/future.rb
+++ b/lib/hcloud/future.rb
@@ -4,10 +4,13 @@ require 'active_support/core_ext/string/inflections'
 
 module Hcloud
   class Future < Delegator
+    attr_reader :raw_data
+
     # rubocop: disable Lint/MissingSuper
-    def initialize(client, target_class, id)
+    def initialize(client, target_class, id, raw_data: nil)
       @target_class = target_class
       @id = id
+      @raw_data = raw_data
       @__client = client
     end
     # rubocop: enable Lint/MissingSuper

--- a/lib/hcloud/image.rb
+++ b/lib/hcloud/image.rb
@@ -15,6 +15,8 @@ module Hcloud
     updatable :description, :type
     destructible
 
+    has_actions
+
     def to_snapshot
       update(type: 'snapshot')
     end

--- a/lib/hcloud/image_resource.rb
+++ b/lib/hcloud/image_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class ImageResource < AbstractResource
-    filter_attributes :type, :bound_to, :name, :label_selector
+    filter_attributes :type, :bound_to, :name, :label_selector, :status, :include_deprecated
 
     bind_to Image
 

--- a/lib/hcloud/network.rb
+++ b/lib/hcloud/network.rb
@@ -40,5 +40,11 @@ module Hcloud
 
       prepare_request('actions/delete_route', j: COLLECT_ARGS.call(__method__, binding))
     end
+
+    def change_ip_range(ip_range:)
+      raise Hcloud::Error::InvalidInput, 'no ip_range given' if ip_range.blank?
+
+      prepare_request('actions/change_ip_range', j: COLLECT_ARGS.call(__method__, binding))
+    end
   end
 end

--- a/lib/hcloud/placement_group_resource.rb
+++ b/lib/hcloud/placement_group_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class PlacementGroupResource < AbstractResource
-    filter_attributes :type, :name
+    filter_attributes :type, :name, :label_selector
 
     bind_to PlacementGroup
 

--- a/lib/hcloud/resource_loader.rb
+++ b/lib/hcloud/resource_loader.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'time'
+
+module Hcloud
+  class ResourceLoader
+    def initialize(schema, client:)
+      @schema = schema
+      @client = client
+    end
+
+    def load(data)
+      load_with_schema(@schema, data)
+    end
+
+    private
+
+    def load_with_schema(schema, data)
+      if schema.respond_to?(:call)
+        schema.call(data, @client)
+      elsif schema.is_a?(Array) && schema.count.positive? && data.is_a?(Array)
+        load_array(schema, data)
+      elsif schema.is_a?(Hash) && data.is_a?(Hash)
+        load_hash(schema, data)
+      else
+        load_single_item(schema, data)
+      end
+    end
+
+    def load_array(schema, data)
+      data.map do |item|
+        load_with_schema(schema[0], item)
+      end
+    end
+
+    def load_hash(schema, data)
+      data.map do |key, value|
+        [key, load_with_schema(schema[key], value)]
+      end.to_h
+    end
+
+    def load_single_item(definition, value)
+      if definition == :time
+        return value ? Time.parse(value) : nil
+      end
+
+      if definition.is_a?(Class) && definition.include?(EntryLoader)
+        return if value.nil?
+
+        # If value is an integer, this is the id of an object which's class can be
+        # retreived from definition. Load a future object that can on access retreive the
+        # data from the api and convert it to a proper object.
+        return Future.new(@client, definition, value) if value.is_a?(Integer)
+
+        # Otherwise the value *is* the content of the object
+        return definition.new(@client, value)
+      end
+
+      value
+    end
+  end
+end

--- a/lib/hcloud/server.rb
+++ b/lib/hcloud/server.rb
@@ -73,10 +73,30 @@ module Hcloud
       prepare_request('actions/detach_from_network', j: { network: network })
     end
 
+    def add_to_placement_group(placement_group:)
+      raise Hcloud::Error::InvalidInput, 'no placement_group given' if placement_group.nil?
+
+      prepare_request('actions/add_to_placement_group', j: COLLECT_ARGS.call(__method__, binding))
+    end
+
+    def change_alias_ips(alias_ips:, network:)
+      raise Hcloud::Error::InvalidInput, 'no alias_ips given' if alias_ips.to_a.count.zero?
+      raise Hcloud::Error::InvalidInput, 'no network given' if network.nil?
+
+      prepare_request('actions/change_alias_ips', j: COLLECT_ARGS.call(__method__, binding))
+    end
+
+    def change_dns_ptr(ip:, dns_ptr:)
+      raise Hcloud::Error::InvalidInput, 'no IP given' if ip.blank?
+      raise Hcloud::Error::InvalidInput, 'no dns_ptr given' if dns_ptr.blank?
+
+      prepare_request('actions/change_dns_ptr', j: COLLECT_ARGS.call(__method__, binding))
+    end
+
     %w[
       poweron poweroff shutdown reboot reset
       disable_rescue disable_backup detach_iso
-      request_console
+      request_console remove_from_placement_group
     ].each do |action|
       define_method(action) do
         prepare_request("actions/#{action}", method: :post)

--- a/lib/hcloud/server.rb
+++ b/lib/hcloud/server.rb
@@ -12,8 +12,19 @@ module Hcloud
       datacenter: Datacenter,
       image: Image,
       iso: Iso,
+      load_balancers: [LoadBalancer],
       placement_group: PlacementGroup,
       private_net: [Network],
+      public_net: {
+        ipv4: lambda do |data, client|
+          Future.new(client, PrimaryIP, data[:id]) if data.to_h[:id].is_a?(Integer)
+        end,
+        ipv6: lambda do |data, client|
+          Future.new(client, PrimaryIP, data[:id]) if data.to_h[:id].is_a?(Integer)
+        end,
+        floating_ips: [FloatingIP],
+        firewalls: [{ id: Firewall }]
+      },
       volumes: [Volume]
     )
 

--- a/lib/hcloud/server.rb
+++ b/lib/hcloud/server.rb
@@ -12,6 +12,7 @@ module Hcloud
       datacenter: Datacenter,
       image: Image,
       iso: Iso,
+      placement_group: PlacementGroup,
       private_net: [Network],
       volumes: [Volume]
     )

--- a/lib/hcloud/server.rb
+++ b/lib/hcloud/server.rb
@@ -23,7 +23,12 @@ module Hcloud
           Future.new(client, PrimaryIP, data[:id]) if data.to_h[:id].is_a?(Integer)
         end,
         floating_ips: [FloatingIP],
-        firewalls: [{ id: Firewall }]
+        firewalls: [
+          lambda do |data, client|
+            Future.new(client, Firewall, data[:id], raw_data: data) if data.to_h[:id].is_a?(Integer)
+          end
+        ]
+        # firewalls: [{ id: Firewall }]
       },
       volumes: [Volume]
     )

--- a/lib/hcloud/server.rb
+++ b/lib/hcloud/server.rb
@@ -22,6 +22,7 @@ module Hcloud
     destructible
 
     has_actions
+    has_metrics
 
     def enable_rescue(type: 'linux64', ssh_keys: [])
       query = COLLECT_ARGS.call(__method__, binding)

--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -12,9 +12,13 @@ module Hcloud
                location: nil,
                start_after_create: nil,
                ssh_keys: [],
+               public_net: nil,
+               firewalls: nil,
                networks: [],
                placement_group: nil,
                user_data: nil,
+               volumes: nil,
+               automount: nil,
                labels: {})
       prepare_request('servers', j: COLLECT_ARGS.call(__method__, binding),
                                  expected_code: 201) do |response|

--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -13,6 +13,7 @@ module Hcloud
                start_after_create: nil,
                ssh_keys: [],
                networks: [],
+               placement_group: nil,
                user_data: nil,
                labels: {})
       prepare_request('servers', j: COLLECT_ARGS.call(__method__, binding),

--- a/lib/hcloud/ssh_key_resource.rb
+++ b/lib/hcloud/ssh_key_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class SSHKeyResource < AbstractResource
-    filter_attributes :name, :label_selector
+    filter_attributes :name, :label_selector, :fingerprint
 
     def [](arg)
       case arg

--- a/lib/hcloud/volume_resource.rb
+++ b/lib/hcloud/volume_resource.rb
@@ -2,7 +2,7 @@
 
 module Hcloud
   class VolumeResource < AbstractResource
-    filter_attributes :name, :label_selector
+    filter_attributes :name, :label_selector, :status
 
     def [](arg)
       case arg

--- a/spec/doubles/servers.rb
+++ b/spec/doubles/servers.rb
@@ -110,22 +110,7 @@ RSpec.shared_context 'servers doubles' do
         :running, :initializing, :starting, :stopping, :off, :deleting, :migrating, :rebuilding, :unknown
       ),
       created: Faker::Time.backward,
-      public_net: {
-        ipv4: {
-          ip: Faker::Internet.ip_v4_address,
-          blocked: random_choice(true, false),
-          dns_ptr: Faker::Internet.domain_name
-        },
-        ipv6: {
-          ip: Faker::Internet.ip_v6_cidr,
-          blocked: random_choice(true, false),
-          dns_ptr: random_choice(
-            [],
-            [{ ip: Faker::Internet.ip_v6_address, dns_ptr: Faker::Internet.domain_name }]
-          )
-        },
-        floating_ips: []
-      },
+      public_net: new_server_public_net,
       private_net: [{
         alias_ips: [],
         ip: '10.0.0.2',
@@ -143,8 +128,30 @@ RSpec.shared_context 'servers doubles' do
       ingoing_traffic: Faker::Number.number,
       included_traffic: Faker::Number.number,
       protection: { delete: random_choice(true, false), rebuild: random_choice(true, false) },
+      placement_group: random_choice(nil, new_placement_group),
       labels: {},
-      volumes: []
+      volumes: Array.new(Faker::Number.within(range: 0..2)).map { new_volume }
     }.deep_merge(kwargs)
+  end
+
+  private
+
+  def new_server_public_net
+    {
+      ipv4: {
+        ip: Faker::Internet.ip_v4_address,
+        blocked: random_choice(true, false),
+        dns_ptr: Faker::Internet.domain_name
+      },
+      ipv6: {
+        ip: Faker::Internet.ip_v6_cidr,
+        blocked: random_choice(true, false),
+        dns_ptr: random_choice(
+          [],
+          [{ ip: Faker::Internet.ip_v6_address, dns_ptr: Faker::Internet.domain_name }]
+        )
+      },
+      floating_ips: []
+    }
   end
 end

--- a/spec/doubles/servers.rb
+++ b/spec/doubles/servers.rb
@@ -129,6 +129,7 @@ RSpec.shared_context 'servers doubles' do
       included_traffic: Faker::Number.number,
       protection: { delete: random_choice(true, false), rebuild: random_choice(true, false) },
       placement_group: random_choice(nil, new_placement_group),
+      load_balancers: Array.new(Faker::Number.within(range: 0..3)).map { Faker::Number.number },
       labels: {},
       volumes: Array.new(Faker::Number.within(range: 0..2)).map { new_volume }
     }.deep_merge(kwargs)
@@ -139,11 +140,13 @@ RSpec.shared_context 'servers doubles' do
   def new_server_public_net
     {
       ipv4: {
+        id: Faker::Number.number,
         ip: Faker::Internet.ip_v4_address,
         blocked: random_choice(true, false),
         dns_ptr: Faker::Internet.domain_name
       },
       ipv6: {
+        id: Faker::Number.number,
         ip: Faker::Internet.ip_v6_cidr,
         blocked: random_choice(true, false),
         dns_ptr: random_choice(
@@ -151,7 +154,10 @@ RSpec.shared_context 'servers doubles' do
           [{ ip: Faker::Internet.ip_v6_address, dns_ptr: Faker::Internet.domain_name }]
         )
       },
-      floating_ips: []
+      firewalls: Array.new(Faker::Number.within(range: 0..5)).map do
+        { id: Faker::Number.number, status: 'applied' }
+      end,
+      floating_ips: Array.new(Faker::Number.within(range: 0..3)).map { Faker::Number.number }
     }
   end
 end

--- a/spec/hcloud/certificate_actions_spec.rb
+++ b/spec/hcloud/certificate_actions_spec.rb
@@ -4,6 +4,9 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Certificate, doubles: :certificate do
+  include_context 'test doubles'
+  include_context 'action tests'
+
   let :certificates do
     Array.new(Faker::Number.within(range: 10..50)).map { new_certificate }
   end
@@ -21,18 +24,7 @@ describe Hcloud::Certificate, doubles: :certificate do
 
   context '#retry' do
     it 'works' do
-      stub_action(:certificates, certificate[:id], :retry) do |_req, _info|
-        {
-          action: build_action_resp(
-            :issue_certificate, :running,
-            resources: [{ id: 42, type: 'certificate' }]
-          )
-        }
-      end
-
-      action = certificate_obj.retry
-      expect(action).to be_a Hcloud::Action
-      expect(action.command).to eq('issue_certificate')
+      test_action(:retry, :issue_certificate)
     end
   end
 end

--- a/spec/hcloud/floating_ip_actions_spec.rb
+++ b/spec/hcloud/floating_ip_actions_spec.rb
@@ -4,6 +4,9 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::FloatingIP, doubles: :floating_ip do
+  include_context 'test doubles'
+  include_context 'action tests'
+
   let :floating_ips do
     Array.new(Faker::Number.within(range: 20..150)).map { new_floating_ip }
   end
@@ -27,45 +30,22 @@ describe Hcloud::FloatingIP, doubles: :floating_ip do
     end
 
     it 'works' do
-      expectation = stub_action(:floating_ips, floating_ip[:id], :assign) do |req, _info|
-        expect(req).to have_body_params(a_hash_including({ 'server' => 42 }))
-
-        {
-          action: build_action_resp(
-            :assign_floating_ip, :success,
-            resources: [
-              { id: 42, type: 'server' },
-              { id: floating_ip[:id], type: 'floating_ip' }
-            ]
-          )
-        }
-      end
-
-      action = floating_ip_obj.assign(server: 42)
-      expect(expectation.times_called).to eq(1)
-      expect(action).to be_a(Hcloud::Action)
-      expect(action.resources.map { |res| res['id'] }).to eq([42, floating_ip[:id]])
+      test_action(
+        :assign,
+        :assign_floating_ip,
+        params: { server: 42 },
+        additional_resources: %i[server]
+      )
     end
   end
 
   context '#unassign' do
     it 'works' do
-      expectation = stub_action(:floating_ips, floating_ip[:id], :unassign) do |_req, _info|
-        {
-          action: build_action_resp(
-            :unassign_floating_ip, :success,
-            resources: [
-              { id: 42, type: 'server' },
-              { id: floating_ip[:id], type: 'floating_ip' }
-            ]
-          )
-        }
-      end
-
-      action = floating_ip_obj.unassign
-      expect(expectation.times_called).to eq(1)
-      expect(action).to be_a(Hcloud::Action)
-      expect(action.resources.map { |res| res['id'] }).to eq([42, floating_ip[:id]])
+      test_action(
+        :unassign,
+        :unassign_floating_ip,
+        additional_resources: %i[server]
+      )
     end
   end
 
@@ -77,28 +57,7 @@ describe Hcloud::FloatingIP, doubles: :floating_ip do
     end
 
     it 'works' do
-      expectation = stub_action(:floating_ips, floating_ip[:id], :change_dns_ptr) do |req, _info|
-        expect(req).to have_body_params(
-          a_hash_including(
-            { 'ip' => '2001:db8::1', 'dns_ptr' => 'example.com' }
-          )
-        )
-
-        {
-          action: build_action_resp(
-            :change_dns_ptr, :success,
-            resources: [
-              { id: floating_ip[:id], type: 'floating_ip' }
-            ]
-          )
-        }
-      end
-
-      action = floating_ip_obj.change_dns_ptr(ip: '2001:db8::1', dns_ptr: 'example.com')
-      expect(expectation.times_called).to eq(1)
-      expect(action).to be_a(Hcloud::Action)
-      expect(action.command).to eq('change_dns_ptr')
-      expect(action.resources[0]['id']).to eq(floating_ip[:id])
+      test_action(:change_dns_ptr, params: { ip: '2001:db8::1', dns_ptr: 'example.com' })
     end
   end
 end

--- a/spec/hcloud/floating_ip_spec.rb
+++ b/spec/hcloud/floating_ip_spec.rb
@@ -47,11 +47,13 @@ describe Hcloud::FloatingIP, doubles: :floating_ip do
     it 'works' do
       params = {
         type: 'ipv4',
+        name: 'moo',
         home_location: 'fsn1',
         labels: { 'key' => 'value', 'novalue' => '' }
       }
       response_params = {
         type: params[:type],
+        name: params[:name],
         home_location: floating_ip[:home_location],
         labels: params[:labels]
       }
@@ -64,14 +66,13 @@ describe Hcloud::FloatingIP, doubles: :floating_ip do
       expect(key.id).to be_a Integer
       expect(key.name).to be_a String
       expect(key.type).to eq('ipv4')
+      expect(key.name).to eq('moo')
       expect(key.home_location).to be_a Hcloud::Location
       expect(key.created).to be_a Time
       expect(key.labels).to eq(params[:labels])
     end
 
     it 'validates uniq name' do
-      pending 'Implementation of floating IP does not support name, yet'
-
       stub_error(:floating_ips, :post, 'uniqueness_error', 409)
 
       expect do

--- a/spec/hcloud/image_actions_spec.rb
+++ b/spec/hcloud/image_actions_spec.rb
@@ -4,6 +4,9 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Image, doubles: :image do
+  include_context 'test doubles'
+  include_context 'action tests'
+
   let :images do
     Array.new(Faker::Number.within(range: 20..150)).map { new_image }
   end
@@ -21,21 +24,7 @@ describe Hcloud::Image, doubles: :image do
 
   context '#change_protection' do
     it 'works' do
-      expectation = stub_action(:images, image[:id], :change_protection) do |req, _info|
-        expect(req).to have_body_params(a_hash_including({ 'delete' => true }))
-
-        {
-          action: build_action_resp(
-            :change_protection, :success,
-            resources: [{ id: 42, type: 'image' }]
-          )
-        }
-      end
-
-      action = image_obj.change_protection(delete: true)
-      expect(expectation.times_called).to eq(1)
-      expect(action).to be_a(Hcloud::Action)
-      expect(action.resources[0]['id']).to eq(42)
+      test_action(:change_protection, params: { delete: true })
     end
   end
 end

--- a/spec/hcloud/image_spec.rb
+++ b/spec/hcloud/image_spec.rb
@@ -7,6 +7,7 @@ require 'support/it_supports_find_by_id_and_name'
 require 'support/it_supports_update'
 require 'support/it_supports_destroy'
 require 'support/it_supports_labels_on_update'
+require 'support/it_supports_action_fetch'
 
 describe Hcloud::Image, doubles: :image do
   let :images do
@@ -26,6 +27,7 @@ describe Hcloud::Image, doubles: :image do
   include_examples 'it_supports_update', described_class, { description: 'new description' }
   include_examples 'it_supports_destroy', described_class
   include_examples 'it_supports_labels_on_update', described_class
+  include_examples 'it_supports_action_fetch', described_class
 
   it '#to_snapshot' do
     expectation = stub_update(:image, image, { type: 'snapshot' })

--- a/spec/hcloud/image_spec.rb
+++ b/spec/hcloud/image_spec.rb
@@ -22,7 +22,7 @@ describe Hcloud::Image, doubles: :image do
 
   include_examples 'it_supports_fetch', described_class
   include_examples 'it_supports_search', described_class, \
-                   %i[type bound_to name label_selector]
+                   %i[type status bound_to include_deprecated name label_selector]
   include_examples 'it_supports_find_by_id_and_name', described_class
   include_examples 'it_supports_update', described_class, { description: 'new description' }
   include_examples 'it_supports_destroy', described_class

--- a/spec/hcloud/load_balancer_spec.rb
+++ b/spec/hcloud/load_balancer_spec.rb
@@ -3,6 +3,7 @@
 require 'active_support/all'
 require 'spec_helper'
 require 'support/it_supports_fetch'
+require 'support/it_supports_search'
 require 'support/it_supports_find_by_id_and_name'
 require 'support/it_supports_update'
 require 'support/it_supports_destroy'
@@ -21,6 +22,7 @@ describe Hcloud::LoadBalancer, doubles: :load_balancer do
   end
 
   include_examples 'it_supports_fetch', described_class
+  include_examples 'it_supports_search', described_class, %i[name label_selector]
   include_examples 'it_supports_find_by_id_and_name', described_class
   include_examples 'it_supports_update', described_class, { name: 'new_name' }
   include_examples 'it_supports_destroy', described_class

--- a/spec/hcloud/load_balancer_type_spec.rb
+++ b/spec/hcloud/load_balancer_type_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'support/it_supports_fetch'
+require 'support/it_supports_search'
 require 'support/it_supports_find_by_id_and_name'
 
 describe Hcloud::LoadBalancerType, doubles: :load_balancer_type do
@@ -16,5 +17,6 @@ describe Hcloud::LoadBalancerType, doubles: :load_balancer_type do
   end
 
   include_examples 'it_supports_fetch', described_class
+  include_examples 'it_supports_search', described_class, %i[name]
   include_examples 'it_supports_find_by_id_and_name', described_class
 end

--- a/spec/hcloud/placement_group_spec.rb
+++ b/spec/hcloud/placement_group_spec.rb
@@ -20,7 +20,7 @@ describe Hcloud::PlacementGroup, doubles: :placement_group do
   end
 
   include_examples 'it_supports_fetch', described_class
-  include_examples 'it_supports_search', described_class, %i[name type]
+  include_examples 'it_supports_search', described_class, %i[name label_selector type]
   include_examples 'it_supports_find_by_id_and_name', described_class
   include_examples 'it_supports_update', described_class, { name: 'new_name' }
   include_examples 'it_supports_destroy', described_class

--- a/spec/hcloud/resource_loader_spec.rb
+++ b/spec/hcloud/resource_loader_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hcloud::ResourceLoader, doubles: :helper do
+  include_context 'test doubles'
+
+  let :sample_location do
+    new_location(name: 'fsn1')
+  end
+
+  it 'can handle time' do
+    loader = Hcloud::ResourceLoader.new({ field: :time }, client: client)
+    result = loader.load({ field: '2022-03-09T10:11:12Z' })
+    expect(result[:field]).to be_a Time
+    expect(result[:field]).to eq(Time.new(2022, 3, 9, 10, 11, 12, 'Z'))
+  end
+
+  context 'can handle EntryLoader classes' do
+    it 'with eagerly loaded objects' do
+      loader = Hcloud::ResourceLoader.new({ field: Hcloud::Location }, client: client)
+      result = loader.load({ field: sample_location })
+      expect(result[:field]).to be_a Hcloud::Location
+    end
+
+    it 'with lazily loaded objects' do
+      stub_item(:locations, sample_location)
+
+      loader = Hcloud::ResourceLoader.new({ field: Hcloud::Location }, client: client)
+      result = loader.load({ field: sample_location[:id] })
+      expect(result[:field]).to be_a Hcloud::Future
+      expect(result[:field].name).to eq('fsn1')
+    end
+  end
+
+  context 'can handle arrays' do
+    it 'of time' do
+      loader = Hcloud::ResourceLoader.new({ field: [:time] }, client: client)
+      result = loader.load({ field: ['2022-03-09T10:11:12Z', '2022-03-12T17:13:16Z'] })
+      expect(result[:field]).to all be_a Time
+      expect(result[:field]).to eq(
+        [
+          Time.new(2022, 3, 9, 10, 11, 12, 'Z'),
+          Time.new(2022, 3, 12, 17, 13, 16, 'Z')
+        ]
+      )
+    end
+
+    it 'of class' do
+      loader = Hcloud::ResourceLoader.new({ field: [Hcloud::Location] }, client: client)
+      result = loader.load({ field: [sample_location, sample_location] })
+      expect(result[:field]).to all be_a Hcloud::Location
+      expect(result[:field].count).to eq(2)
+    end
+
+    it 'by keeping value when data is not an array' do
+      loader = Hcloud::ResourceLoader.new({ field: [Hcloud::Location] }, client: client)
+      result = loader.load({ field: sample_location })
+      expect(result[:field]).to be_a Hash
+      expect(result.dig(:field, :name)).to eq('fsn1')
+    end
+  end
+
+  it 'can handle nested hashes' do
+    schema = {
+      field1: Hcloud::Location,
+      field2: {
+        sub_field: [Hcloud::Location]
+      }
+    }
+    data = {
+      field1: sample_location,
+      field2: {
+        sub_field: [sample_location]
+      },
+      field3: 'data-without-schema'
+    }
+
+    loader = Hcloud::ResourceLoader.new(schema, client: client)
+    result = loader.load(data)
+
+    expect(result[:field1]).to be_a Hcloud::Location
+    expect(result.dig(:field2, :sub_field)).to all be_a Hcloud::Location
+    expect(result.dig(:field2, :sub_field).count).to eq(1)
+    expect(result[:field3]).to eq('data-without-schema')
+  end
+
+  it 'can handle lists with nested structures' do
+    schema = { field: [{ field: Hcloud::Location }] }
+    data = {
+      field: [
+        { field: sample_location, other: 'data-without-schema' },
+        { field: sample_location, other: 'more-data-without-schema' }
+      ]
+    }
+
+    loader = Hcloud::ResourceLoader.new(schema, client: client)
+    result = loader.load(data)
+
+    expect(result[:field].map { |item| item[:field] }).to all be_a Hcloud::Location
+    expect(result[:field].map { |item| item[:field] }.map(&:name)).to all eq('fsn1')
+    expect(result[:field][0][:other]).to eq('data-without-schema')
+    expect(result[:field][1][:other]).to eq('more-data-without-schema')
+  end
+
+  it 'can use an extractor' do
+    stub_item(:locations, sample_location)
+
+    schema = {
+      field: lambda do |data, client|
+        Hcloud::Future.new(client, Hcloud::Location, data[:id])
+      end
+    }
+    data = {
+      field: {
+        id: sample_location[:id]
+      }
+    }
+
+    loader = Hcloud::ResourceLoader.new(schema, client: client)
+    result = loader.load(data)
+
+    expect(result[:field]).to be_a(Hcloud::Future).and have_attributes(name: 'fsn1')
+  end
+end

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -7,6 +7,7 @@ require 'support/it_supports_find_by_id_and_name'
 require 'support/it_supports_update'
 require 'support/it_supports_destroy'
 require 'support/it_supports_labels_on_update'
+require 'support/it_supports_metrics'
 require 'support/it_supports_action_fetch'
 
 RSpec.describe Hcloud::Server, doubles: :server do
@@ -26,6 +27,7 @@ RSpec.describe Hcloud::Server, doubles: :server do
   include_examples 'it_supports_update', described_class, { name: 'new_name' }
   include_examples 'it_supports_destroy', described_class
   include_examples 'it_supports_labels_on_update', described_class
+  include_examples 'it_supports_metrics', described_class, %i[cpu disk network]
   include_examples 'it_supports_action_fetch', described_class
 
   it 'fetch server' do

--- a/spec/hcloud/ssh_key_spec.rb
+++ b/spec/hcloud/ssh_key_spec.rb
@@ -24,7 +24,7 @@ describe Hcloud::SSHKey, doubles: :ssh_key do
   end
 
   include_examples 'it_supports_fetch', described_class
-  include_examples 'it_supports_search', described_class, %i[name label_selector]
+  include_examples 'it_supports_search', described_class, %i[name fingerprint label_selector]
   include_examples 'it_supports_find_by_id_and_name', described_class
   include_examples 'it_supports_update', described_class, { name: 'new_name' }
   include_examples 'it_supports_destroy', described_class

--- a/spec/hcloud/volume_spec.rb
+++ b/spec/hcloud/volume_spec.rb
@@ -22,7 +22,7 @@ describe Hcloud::Volume, doubles: :volume do
   end
 
   include_examples 'it_supports_fetch', described_class
-  include_examples 'it_supports_search', described_class, %i[name label_selector]
+  include_examples 'it_supports_search', described_class, %i[status name label_selector]
   include_examples 'it_supports_find_by_id_and_name', described_class
   include_examples 'it_supports_update', described_class, { name: 'new_name' }
   include_examples 'it_supports_destroy', described_class

--- a/spec/support/it_supports_metrics.rb
+++ b/spec/support/it_supports_metrics.rb
@@ -25,6 +25,10 @@ RSpec.shared_examples 'it_supports_metrics' do |resource, metrics|
         end: params[:end],
         step: step,
         time_series: {
+          # In reality the time series name does not necessarily have to be the same
+          # as the queried type. E.g. server metrics for the type "network" returns multiple time
+          # series called "network.0.pps.in", "network.0.pps.out" and so on. But for our unit
+          # tests returning a single time series is enough at the moment.
           params[:type].to_sym => {
             # generate a random length list of a few random values
             values: Array.new(Faker::Number.within(range: 0..100)).map.with_index do |_, idx|


### PR DESCRIPTION
Implementing the missing features of existing resources (new actions, new attributes) in this PR.

List of requirements compiled from #30 

Some server attributes have already been implemented before this PR.

(!) = Blocked by other PR

- [x] Images have Actions
- [x] Servers have metrics
- [x] Servers Action add_to_placement_group
- [x] Servers Action change_alias_ips
- [x] Servers Action change_dns_ptr
- [x] Servers Action remove_from_placement_group
- [x] Server attribute backup_window
- [x] Server attribute iso (resource type)
- [x] Server attribute labels (currently hash)
- [x] (!) #55 Server attribute load_balancers (currently array) (resource type)
- [x] Server attribute placement_group (resource type)
- [x] Server attribute private_net (currently array) (resource type)
- [x] Server attribute protection ({"delete"=>false, "rebuild"=>false})
- [x] Server attribute public_net (currently hash), has sub fields that are resource types
  - [x] primary IPs
  - [x] floating IPs
  - [x] firewalls (this one is a bit harder to handle as next to the ID it has the additional field `status`, which describes the relationship between the server and the firewall)
    - [x] open issue: the ID is in a hash in the `:id` key, so the parsed firewall object also is in the `:id` key
- [x] Server attribute volumes (currently list) (resource type)
- [x] Network Action change_ip_range
- [x] Floating IPs parameter name on create
- [x] Floating IPs parameter name on update
- [x] Image parameter status on get all
- [x] Image parameter include_deprecated on get all
- [x] Placement groups parameter label_selector on get all
- [x] Server parameter automount on create
- [x] Server parameter firewalls on create
- [x] Server parameter placement_group on create
- [x] Server parameter public_net on create
- [x] Server parameter volumes on create
- [x] SSH key parameter fingerprint on get all
- [x] Volume parameter status on get all

TODO after #55 merged:

- [x] add `it_supports_search` to load balancer spec
- [x] add `it_supports_search` to load balancer type spec

Closes #30