### PR TITLE
lib: fetch pricing from API

### DIFF
--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -12,6 +12,9 @@ module Hcloud
   autoload :AbstractResource, 'hcloud/abstract_resource'
   autoload :EntryLoader, 'hcloud/entry_loader'
 
+  autoload :Pricing, 'hcloud/pricing'
+  autoload :PricingResource, 'hcloud/pricing_resource'
+
   autoload :Server, 'hcloud/server'
   autoload :ServerResource, 'hcloud/server_resource'
 

--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -13,7 +13,7 @@ module Hcloud
   autoload :EntryLoader, 'hcloud/entry_loader'
 
   autoload :Pricing, 'hcloud/pricing'
-  autoload :PricingResource, 'hcloud/pricing_resource'
+  autoload :PriceMatrix, 'hcloud/price_matrix'
 
   autoload :Server, 'hcloud/server'
   autoload :ServerResource, 'hcloud/server_resource'

--- a/lib/hcloud/client.rb
+++ b/lib/hcloud/client.rb
@@ -54,8 +54,8 @@ module Hcloud
       false
     end
 
-    def pricings
-      PricingResource.new(client: self)
+    def pricing
+      @pricing ||= Pricing.new(self)
     end
 
     def servers

--- a/lib/hcloud/client.rb
+++ b/lib/hcloud/client.rb
@@ -54,6 +54,10 @@ module Hcloud
       false
     end
 
+    def pricings
+      PricingResource.new(client: self)
+    end
+
     def servers
       ServerResource.new(client: self)
     end

--- a/lib/hcloud/price_matrix.rb
+++ b/lib/hcloud/price_matrix.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Hcloud
+  class PriceMatrix
+    extend Forwardable
+    include Enumerable
+
+    def_delegator :@prices, :each
+
+    def initialize(prices, type)
+      validate_prices(prices)
+
+      @prices = prices
+      @type = type
+      @attributes = prices[0].to_h.keys.reject { |key| key == :prices }
+    end
+
+    def filter(**kwargs)
+      PriceMatrix.new(filter_raw(kwargs), @type)
+    end
+
+    def estimated_cost(location, **kwargs)
+      filter_keys, calc_keys = kwargs.keys.partition { |key| @attributes.include?(key) }
+      filter_args = kwargs.slice(*filter_keys)
+      filter_args = filter_args.merge(location: location) if @attributes.include?(:location)
+
+      entries = filter_raw(filter_args)
+      # TODO: Not so nice behaviour for users
+      unless entries.count == 1
+        raise Hcloud::Error::InvalidInput,
+              "could not filter to a single element, got #{entries.count}"
+      end
+
+      calc_cost(kwargs.slice(*calc_keys), entries[0][:prices])
+    end
+
+    private
+
+    def calc_cost(calc_args, prices)
+      # TODO: How to standardize this more?
+      case @type
+      when :floating_ip
+        calc_month_based(calc_args, prices, months_key: :months)
+      when :primary_ip
+        calc_hour_based(calc_args, prices, hours_key: :hours)
+      when :image, :volume
+        calc_gb_based(calc_args, prices)
+      when :load_balancer_type, :server_type
+        calc_hour_based(calc_args, prices, hours_key: :runtime_hours)
+      when :traffic
+        calc_traffic(calc_args, prices)
+      end
+    end
+
+    def validate_prices(prices)
+      unless prices.all? { |entry| entry.key?(:prices) }
+        raise Hcloud::Error::InvalidInput, 'Key "prices" missing in pricing data'
+      end
+
+      prices.each do |entry|
+        entry[:prices].each do |type, price|
+          unless price.key?(:net)
+            raise Hcloud::Error::InvalidInput, "Key \"net\" missing for price \"#{type}\""
+          end
+        end
+      end
+    end
+
+    def filter_raw(filters)
+      @prices.select do |price|
+        price.all? do |key, value|
+          !filters.key?(key) || filters[key] == value
+        end
+      end
+    end
+
+    def calc_hour_based(calc_args, price, hours_key:)
+      check_keys(calc_args.keys, [hours_key])
+
+      # TODO: Take into account monthly cap for capped prices. Add a spec for it.
+      price[:price_hourly][:net] * calc_args[hours_key]
+    end
+
+    def calc_month_based(calc_args, price, months_key:)
+      check_keys(calc_args.keys, [months_key])
+
+      price[:price_monthly][:net] * calc_args[months_key]
+    end
+
+    def calc_gb_based(calc_args, price)
+      check_keys(calc_args.keys, [:size_gb])
+
+      price[:price_per_gb_month][:net] * calc_args[:size_gb]
+    end
+
+    def calc_traffic(calc_args, price)
+      check_keys(calc_args.keys, [:traffic_tb])
+
+      price[:price_per_tb][:net] * calc_args[:traffic_tb]
+    end
+
+    def check_keys(keys, required, allowed = nil)
+      allowed ||= required
+
+      check_required_keys(keys, required)
+      check_allowed_keys(keys, allowed)
+    end
+
+    def check_allowed_keys(keys, allowed_keys)
+      diff = keys.difference(allowed_keys)
+
+      return if diff.empty?
+
+      raise Hcloud::Error::InvalidInput, "Parameter(s) \"#{diff.join(', ')}\" not allowed"
+    end
+
+    def check_required_keys(keys, required_keys)
+      diff = required_keys.difference(keys)
+
+      return if diff.empty?
+
+      raise Hcloud::Error::InvalidInput, "Parameter(s) \"#{diff.join(', ')}\" missing"
+    end
+  end
+end

--- a/lib/hcloud/pricing.rb
+++ b/lib/hcloud/pricing.rb
@@ -1,13 +1,83 @@
 # frozen_string_literal: true
 
+require 'bigdecimal'
+
 module Hcloud
   class Pricing
-    require 'hcloud/pricing_resource'
+    require 'hcloud/price_matrix'
 
-    include EntryLoader
+    attr_reader :currency
 
-    def resource_url
-      'pricing'
+    def initialize(client)
+      @client = client
+      reload
+    end
+
+    def respond_to_missing?(method_name, include_all = false)
+      @matrices.key?(method_name) || super
+    end
+
+    def method_missing(method_name, *args)
+      @matrices[method_name] || super
+    end
+
+    private
+
+    def reload # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      @matrices = {}
+
+      @client.prepare_request('pricing') do |response|
+        data = response.parsed_json[:pricing]
+
+        @currency = data[:currency]
+        @matrices[:floating_ips] = Hcloud::PriceMatrix.new(
+          parse_location_pricing(data[:floating_ips]), :floating_ip
+        )
+        @matrices[:images] = Hcloud::PriceMatrix.new(parse_global_pricing(data[:image]), :image)
+        @matrices[:load_balancer_types] = Hcloud::PriceMatrix.new(
+          parse_location_pricing(data[:load_balancer_types]), :load_balancer_type
+        )
+        @matrices[:primary_ips] = Hcloud::PriceMatrix.new(
+          parse_location_pricing(data[:primary_ips]), :primary_ip
+        )
+        # TODO: Server backup does not fulfill the current requirement to have a "net" key
+        @matrices[:server_types] = Hcloud::PriceMatrix.new(
+          parse_location_pricing(data[:server_types]), :server_type
+        )
+        @matrices[:traffic] = Hcloud::PriceMatrix.new(
+          parse_global_pricing(data[:traffic]), :traffic
+        )
+        @matrices[:volumes] = Hcloud::PriceMatrix.new(parse_global_pricing(data[:volume]), :volume)
+      end
+    end
+
+    def parse_global_pricing(pricing)
+      pricing.each do |key, value|
+        pricing[key][:net] = BigDecimal(value[:net])
+        pricing[key][:gross] = BigDecimal(value[:gross])
+      end
+
+      [{ prices: pricing }]
+    end
+
+    def parse_location_pricing(pricing)
+      result = []
+
+      pricing.each do |per_type|
+        prices = per_type.delete(:prices)
+        prices.each do |per_location|
+          location = per_location.delete(:location)
+
+          per_location.each do |key, value|
+            per_location[key][:net] = BigDecimal(value[:net])
+            per_location[key][:gross] = BigDecimal(value[:gross])
+          end
+
+          result << per_type.merge(prices: per_location).merge(location: location)
+        end
+      end
+
+      result
     end
   end
 end

--- a/lib/hcloud/pricing.rb
+++ b/lib/hcloud/pricing.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Hcloud
+  class Pricing
+    require 'hcloud/pricing_resource'
+
+    include EntryLoader
+
+    def resource_url
+      'pricing'
+    end
+  end
+end

--- a/lib/hcloud/pricing_resource.rb
+++ b/lib/hcloud/pricing_resource.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Hcloud
+  class PricingResource < AbstractResource
+    bind_to Pricing
+
+    def fetch
+      prepare_request('pricing', method: :get) do |response|
+        Pricing.new(client, response.parsed_json[:pricing])
+      end
+    end
+  end
+end

--- a/spec/doubles/base.rb
+++ b/spec/doubles/base.rb
@@ -23,7 +23,7 @@ RSpec.shared_context 'test doubles' do
   %w[actions certificates datacenters firewalls floating_ips images isos
      load_balancers load_balancer_types
      locations networks servers server_types ssh_keys placement_groups
-     primary_ips volumes].each do |kind|
+     pricings primary_ips volumes].each do |kind|
     require_relative "./#{kind}"
     include_context "#{kind} doubles"
   end

--- a/spec/doubles/pricings.rb
+++ b/spec/doubles/pricings.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'pricings doubles' do
+  def new_pricing(kwargs = {})
+    {
+      pricing: {
+        currency: Faker::Currency.code,
+        floating_ip: {
+          price_monthly: new_pricings_price
+        },
+        floating_ips: [
+          {
+            prices: new_pricings_regional(hourly: false),
+            type: random_choice('ipv4', 'ipv6')
+          }
+        ],
+        image: {
+          price_per_gb_month: new_pricings_price
+        },
+        load_balancer_types: [
+          {
+            id: Faker::Number.number,
+            name: Faker::Internet.slug,
+            prices: new_pricings_regional
+          }
+        ],
+        primary_ips: [
+          {
+            type: random_choice('ipv4', 'ipv6'),
+            prices: new_pricings_regional
+          }
+        ],
+        server_backup: {
+          percentage: Faker::Number.within(range: 0.0..100.0)
+        },
+        server_types: [
+          {
+            id: Faker::Number.number,
+            name: Faker::Internet.slug,
+            prices: new_pricings_regional
+          }
+        ],
+        traffic: {
+          price_per_tb: new_pricings_price
+        },
+        vat_rate: Faker::Number.within(range: 5.0..35.0),
+        volume: {
+          price_per_gb_month: new_pricings_price
+        }
+      }
+    }.deep_merge(kwargs)
+  end
+
+  private
+
+  def new_pricings_price
+    {
+      gross: Faker::Number.decimal.to_s,
+      net: Faker::Number.decimal.to_s
+    }
+  end
+
+  def new_pricings_regional(hourly: true, monthly: true)
+    price = {
+      location: Faker::Internet.slug
+    }
+
+    price[:price_hourly] = new_pricings_price if hourly
+    price[:price_monthly] = new_pricings_price if monthly
+
+    [price]
+  end
+end

--- a/spec/hcloud/price_matrix_spec.rb
+++ b/spec/hcloud/price_matrix_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'hcloud/errors'
+require 'hcloud/price_matrix'
+require 'faker'
+
+RSpec.describe Hcloud::PriceMatrix do
+  def time_price
+    {
+      price_hourly: {
+        gross: Faker::Number.decimal,
+        net: Faker::Number.decimal
+      },
+      price_monthly: {
+        gross: Faker::Number.decimal,
+        net: Faker::Number.decimal
+      }
+    }
+  end
+
+  let :matrix do
+    prices = [{
+      id: Faker::Number.number,
+      name: 'cx11',
+      location: 'fsn1',
+      prices: time_price
+    }, {
+      id: Faker::Number.number,
+      name: 'cx11',
+      location: 'nbg1',
+      prices: time_price
+    }, {
+      id: Faker::Number.number,
+      name: 'cx21',
+      location: 'fsn1',
+      prices: time_price
+    }, {
+      id: Faker::Number.number,
+      name: 'cx21',
+      location: 'hel1',
+      prices: time_price
+    }]
+    Hcloud::PriceMatrix.new(prices, :server_type)
+  end
+
+  context 'with invalid input' do
+    it 'detects missing prices' do
+      prices = [{
+        name: 'cx11',
+        price_monthly: {
+          net: Faker::Number.number,
+          gross: Faker::Number.number
+        }
+      }]
+      expect { Hcloud::PriceMatrix.new(prices, :server_type) }.to(
+        raise_error Hcloud::Error::InvalidInput
+      )
+    end
+
+    it 'detects missing net price' do
+      prices = [{
+        name: 'cx11',
+        prices: {
+          price_monthly: {
+            gross: Faker::Number.number
+          }
+        }
+      }]
+      expect { Hcloud::PriceMatrix.new(prices, :server_type) }.to(
+        raise_error Hcloud::Error::InvalidInput
+      )
+    end
+  end
+
+  it 'can be iterated' do
+    expect(matrix).to respond_to(:each)
+  end
+
+  context '#filter' do
+    let :filtered do
+      matrix.filter(name: 'cx11')
+    end
+
+    it 'returns a price matrix' do
+      expect(filtered).to be_a(Hcloud::PriceMatrix)
+    end
+
+    it 'contains only filtered items' do
+      expect(filtered).to all(satisfy { |item| item[:name] == 'cx11' })
+    end
+  end
+
+  context '#estimate_cost' do
+    it 'raises on too few filters' do
+      expect do
+        # without a name we do not know for which server type the price should be estimated
+        matrix.estimated_cost('fsn1', runtime_hours: 'bar')
+      end.to raise_error Hcloud::Error::InvalidInput
+    end
+
+    it 'raises on invalid attribute' do
+      expect do
+        matrix.estimated_cost('fsn1', name: 'cx11', foo: 'bar')
+      end.to raise_error Hcloud::Error::InvalidInput
+    end
+
+    it 'raises on missing calculation attributes' do
+      expect do
+        # without a runtime we do not know for how many hours we should estimate
+        matrix.estimated_cost('fsn1', name: 'cx11')
+      end.to raise_error Hcloud::Error::InvalidInput
+    end
+
+    it 'can estimate cost' do
+      cost = matrix.estimated_cost('fsn1', name: 'cx11', runtime_hours: 100)
+      expect(cost).to be_a_kind_of(Numeric)
+    end
+
+    it 'can handle wildcard location' do
+      # Some prices are announced as the same price in all regions.
+      # In PriceMatrix we omit the location entry for those prices.
+      # The user # still has to specify it, because (to be future-proof) we always require
+      # a location to be specified.
+      prices = [{
+        prices: {
+          price_per_gb_month: {
+            net: Faker::Number.number,
+            gross: Faker::Number.number
+          }
+        }
+      }]
+      matrix = Hcloud::PriceMatrix.new(prices, :volume)
+
+      expect(matrix.estimated_cost('fsn1', size_gb: 100)).to be_a_kind_of(Numeric)
+    end
+  end
+end

--- a/spec/hcloud/pricing_spec.rb
+++ b/spec/hcloud/pricing_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Hcloud::Pricing, doubles: :pricing do
+  include_context 'test doubles'
+
+  let(:pricing) { new_pricing }
+
+  let :client do
+    Hcloud::Client.new(token: 'secure')
+  end
+
+  it 'fetches pricing overview' do
+    stub('pricing') do |_req, _info|
+      {
+        body: pricing,
+        code: 200
+      }
+    end
+
+    pricing = client.pricings.fetch
+    expect(pricing.currency).to be_a String
+    expect(pricing.image[:price_per_gb_month][:gross]).to be_a String
+    expect(pricing.image[:price_per_gb_month][:net]).to be_a String
+  end
+end

--- a/spec/hcloud/pricing_spec.rb
+++ b/spec/hcloud/pricing_spec.rb
@@ -5,23 +5,89 @@ require 'spec_helper'
 describe Hcloud::Pricing, doubles: :pricing do
   include_context 'test doubles'
 
-  let(:pricing) { new_pricing }
+  let(:api_pricing) { new_pricing }
 
   let :client do
-    Hcloud::Client.new(token: 'secure')
-  end
-
-  it 'fetches pricing overview' do
     stub('pricing') do |_req, _info|
       {
-        body: pricing,
+        body: api_pricing,
         code: 200
       }
     end
 
-    pricing = client.pricings.fetch
-    expect(pricing.currency).to be_a String
-    expect(pricing.image[:price_per_gb_month][:gross]).to be_a String
-    expect(pricing.image[:price_per_gb_month][:net]).to be_a String
+    Hcloud::Client.new(token: 'secure')
+  end
+
+  it 'fetches pricing overview' do
+    expect(client.pricing).to have_attributes(
+      currency: a_kind_of(String),
+      floating_ips: a_kind_of(Hcloud::PriceMatrix),
+      images: a_kind_of(Hcloud::PriceMatrix),
+      load_balancer_types: a_kind_of(Hcloud::PriceMatrix),
+      primary_ips: a_kind_of(Hcloud::PriceMatrix),
+      server_types: a_kind_of(Hcloud::PriceMatrix),
+      traffic: a_kind_of(Hcloud::PriceMatrix),
+      volumes: a_kind_of(Hcloud::PriceMatrix)
+    )
+  end
+
+  context 'cost estimation' do
+    let(:pricing) { client.pricing }
+
+    it 'can estimate floating IP cost' do
+      type = api_pricing[:pricing][:floating_ips][0][:type]
+      location = api_pricing[:pricing][:floating_ips][0][:prices][0][:location]
+
+      expect(
+        pricing.floating_ips.estimated_cost(
+          location, type: type, months: 2
+        )
+      ).to be_a_kind_of(Numeric)
+    end
+
+    it 'can estimate image cost' do
+      expect(pricing.images.estimated_cost('fsn1', size_gb: 100)).to be_a_kind_of(Numeric)
+    end
+
+    it 'can estimate load balancer cost' do
+      name = api_pricing[:pricing][:load_balancer_types][0][:name]
+      location = api_pricing[:pricing][:load_balancer_types][0][:prices][0][:location]
+
+      expect(
+        pricing.load_balancer_types.estimated_cost(
+          location, name: name, runtime_hours: 3
+        )
+      ).to be_a_kind_of(Numeric)
+    end
+
+    it 'can estimate primary IP cost' do
+      type = api_pricing[:pricing][:primary_ips][0][:type]
+      location = api_pricing[:pricing][:primary_ips][0][:prices][0][:location]
+
+      expect(
+        pricing.primary_ips.estimated_cost(
+          location, type: type, hours: 3
+        )
+      ).to be_a_kind_of(Numeric)
+    end
+
+    it 'can estimate server cost' do
+      name = api_pricing[:pricing][:server_types][0][:name]
+      location = api_pricing[:pricing][:server_types][0][:prices][0][:location]
+
+      expect(
+        pricing.server_types.estimated_cost(
+          location, name: name, runtime_hours: 3
+        )
+      ).to be_a_kind_of(Numeric)
+    end
+
+    it 'can estimate traffic cost' do
+      expect(pricing.traffic.estimated_cost('fsn1', traffic_tb: 5)).to be_a_kind_of(Numeric)
+    end
+
+    it 'can estimate volume cost' do
+      expect(pricing.volumes.estimated_cost('fsn1', size_gb: 100)).to be_a_kind_of(Numeric)
+    end
   end
 end


### PR DESCRIPTION
Pricing is a bit different than the other resource types. It only provides a single API endpoint `/pricing`. On this it only returns a single dictionary. All other resource types return an array of resources and have a `/<resource>/<id>` endpoint for single resources.

Our concept of `<X>` and `<X>Resource` classes currently maps to the latter concept.

I tried two different approaches for a user of our client:

Stick to the same concept as closely as possible. This is the one implemented now.

```ruby
pricing = client.pricings.fetch
expect(pricing.currency).to be_a String
```

Only use a `Pricing` class or forward all calls from `PricingResource` to `Pricing`.

```ruby
expect(client.pricing.currency).to be_a String
```

The second approach in my opinion would be nicer for a user, but had some complications. Without special additions to the code the client will on each call to `client.pricing` issue a new API request. This would cause needlessly many API requests if a user checks a few prices. A fix to this would be that the `Client` has to cache some information (pricing or pricing resource). Currently, it just creates a new instance of `<X>Resource` whenever an attribute is called.

Closes #28 