### PR TITLE
spec: include context doubles for doubles tests

### DIFF
--- a/spec/hcloud/action_spec.rb
+++ b/spec/hcloud/action_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Hcloud::Action, doubles: :action do
-  include_context 'test doubles'
-
   let :actions do
     Array.new(Faker::Number.within(range: 20..150)).map { new_action }
   end

--- a/spec/hcloud/certificate_actions_spec.rb
+++ b/spec/hcloud/certificate_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Certificate, doubles: :certificate do
-  include_context 'test doubles'
-
   let :certificates do
     Array.new(Faker::Number.within(range: 10..50)).map { new_certificate }
   end

--- a/spec/hcloud/certificate_spec.rb
+++ b/spec/hcloud/certificate_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 describe Hcloud::Certificate, doubles: :certificate do
-  include_context 'test doubles'
-
   let :certificates do
     Array.new(Faker::Number.within(range: 20..150)).map { new_certificate }
   end

--- a/spec/hcloud/datacenter_spec.rb
+++ b/spec/hcloud/datacenter_spec.rb
@@ -6,8 +6,6 @@ require 'support/it_supports_search'
 require 'support/it_supports_find_by_id_and_name'
 
 describe Hcloud::Datacenter, doubles: :datacenter do
-  include_context 'test doubles'
-
   let :datacenters do
     Array.new(Faker::Number.within(range: 20..150)).map { new_datacenter }
   end

--- a/spec/hcloud/firewall_actions_spec.rb
+++ b/spec/hcloud/firewall_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Firewall, doubles: :firewall do
-  include_context 'test doubles'
-
   let :firewalls do
     Array.new(Faker::Number.within(range: 20..150)).map { new_firewall }
   end

--- a/spec/hcloud/firewall_spec.rb
+++ b/spec/hcloud/firewall_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 describe Hcloud::Firewall, doubles: :firewall do
-  include_context 'test doubles'
-
   let :firewalls do
     Array.new(Faker::Number.within(range: 20..150)).map { new_firewall }
   end

--- a/spec/hcloud/floating_ip_actions_spec.rb
+++ b/spec/hcloud/floating_ip_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::FloatingIP, doubles: :floating_ip do
-  include_context 'test doubles'
-
   let :floating_ips do
     Array.new(Faker::Number.within(range: 20..150)).map { new_floating_ip }
   end

--- a/spec/hcloud/floating_ip_spec.rb
+++ b/spec/hcloud/floating_ip_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 describe Hcloud::FloatingIP, doubles: :floating_ip do
-  include_context 'test doubles'
-
   let :floating_ips do
     Array.new(Faker::Number.within(range: 20..150)).map { new_floating_ip }
   end

--- a/spec/hcloud/image_actions_spec.rb
+++ b/spec/hcloud/image_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Image, doubles: :image do
-  include_context 'test doubles'
-
   let :images do
     Array.new(Faker::Number.within(range: 20..150)).map { new_image }
   end

--- a/spec/hcloud/image_spec.rb
+++ b/spec/hcloud/image_spec.rb
@@ -9,8 +9,6 @@ require 'support/it_supports_destroy'
 require 'support/it_supports_labels_on_update'
 
 describe Hcloud::Image, doubles: :image do
-  include_context 'test doubles'
-
   let :images do
     Array.new(Faker::Number.within(range: 20..150)).map { new_image }
   end

--- a/spec/hcloud/iso_spec.rb
+++ b/spec/hcloud/iso_spec.rb
@@ -6,8 +6,6 @@ require 'support/it_supports_search'
 require 'support/it_supports_find_by_id_and_name'
 
 describe Hcloud::Iso, doubles: :iso do
-  include_context 'test doubles'
-
   let :isos do
     Array.new(Faker::Number.within(range: 20..150)).map { new_iso }
   end

--- a/spec/hcloud/load_balancer_actions_spec.rb
+++ b/spec/hcloud/load_balancer_actions_spec.rb
@@ -4,7 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::LoadBalancer, doubles: :load_balancer do
-  include_context 'test doubles'
   include_context 'action tests'
 
   let :load_balancers do

--- a/spec/hcloud/load_balancer_spec.rb
+++ b/spec/hcloud/load_balancer_spec.rb
@@ -10,8 +10,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_metrics'
 
 describe Hcloud::LoadBalancer, doubles: :load_balancer do
-  include_context 'test doubles'
-
   let :load_balancers do
     Array.new(Faker::Number.within(range: 10..50)).map { new_load_balancer }
   end

--- a/spec/hcloud/load_balancer_type_spec.rb
+++ b/spec/hcloud/load_balancer_type_spec.rb
@@ -5,8 +5,6 @@ require 'support/it_supports_fetch'
 require 'support/it_supports_find_by_id_and_name'
 
 describe Hcloud::LoadBalancerType, doubles: :load_balancer_type do
-  include_context 'test doubles'
-
   let :load_balancer_types do
     Array.new(Faker::Number.within(range: 5..20)).map { new_load_balancer_type }
   end

--- a/spec/hcloud/location_spec.rb
+++ b/spec/hcloud/location_spec.rb
@@ -6,8 +6,6 @@ require 'support/it_supports_search'
 require 'support/it_supports_find_by_id_and_name'
 
 describe Hcloud::Location, doubles: :location do
-  include_context 'test doubles'
-
   let :locations do
     Array.new(Faker::Number.within(range: 20..150)).map { new_location }
   end

--- a/spec/hcloud/network_actions_spec.rb
+++ b/spec/hcloud/network_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Network, doubles: :network do
-  include_context 'test doubles'
-
   let :networks do
     Array.new(Faker::Number.within(range: 20..150)).map { new_network }
   end

--- a/spec/hcloud/network_spec.rb
+++ b/spec/hcloud/network_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 describe Hcloud::Network, doubles: :network do
-  include_context 'test doubles'
-
   let :networks do
     Array.new(Faker::Number.within(range: 20..150)).map { new_network }
   end

--- a/spec/hcloud/placement_group_spec.rb
+++ b/spec/hcloud/placement_group_spec.rb
@@ -9,8 +9,6 @@ require 'support/it_supports_destroy'
 require 'support/it_supports_labels_on_update'
 
 describe Hcloud::PlacementGroup, doubles: :placement_group do
-  include_context 'test doubles'
-
   let :placement_groups do
     Array.new(Faker::Number.within(range: 20..150)).map { new_placement_group }
   end

--- a/spec/hcloud/primary_ip_actions_spec.rb
+++ b/spec/hcloud/primary_ip_actions_spec.rb
@@ -4,7 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::PrimaryIP, doubles: :primary_ip do
-  include_context 'test doubles'
   include_context 'action tests'
 
   let :primary_ips do

--- a/spec/hcloud/primary_ip_spec.rb
+++ b/spec/hcloud/primary_ip_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 describe Hcloud::PrimaryIP, doubles: :primary_ip do
-  include_context 'test doubles'
-
   let :primary_ips do
     Array.new(Faker::Number.within(range: 20..150)).map { new_primary_ip }
   end

--- a/spec/hcloud/server_actions_spec.rb
+++ b/spec/hcloud/server_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Server, doubles: :server do
-  include_context 'test doubles'
-
   let :servers do
     Array.new(Faker::Number.within(range: 20..150)).map { new_server }
   end

--- a/spec/hcloud/server_spec.rb
+++ b/spec/hcloud/server_spec.rb
@@ -10,8 +10,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 RSpec.describe Hcloud::Server, doubles: :server do
-  include_context 'test doubles'
-
   let :servers do
     Array.new(Faker::Number.within(range: 20..150)).map { new_server }
   end

--- a/spec/hcloud/server_type_spec.rb
+++ b/spec/hcloud/server_type_spec.rb
@@ -6,8 +6,6 @@ require 'support/it_supports_search'
 require 'support/it_supports_find_by_id_and_name'
 
 describe Hcloud::ServerType, doubles: :server_type do
-  include_context 'test doubles'
-
   let :server_types do
     Array.new(Faker::Number.within(range: 20..150)).map { new_server_type }
   end

--- a/spec/hcloud/ssh_key_spec.rb
+++ b/spec/hcloud/ssh_key_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 SSH_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILh8GHJkJRgf3wuuUUQYG3UfqtVK56+FEXAOFaNZ659C m@x.com'
 
 describe Hcloud::SSHKey, doubles: :ssh_key do
-  include_context 'test doubles'
-
   let :ssh_keys do
     Array.new(Faker::Number.within(range: 20..150)).map { new_ssh_key }
   end

--- a/spec/hcloud/volume_actions_spec.rb
+++ b/spec/hcloud/volume_actions_spec.rb
@@ -4,8 +4,6 @@ require 'active_support/all'
 require 'spec_helper'
 
 describe Hcloud::Volume, doubles: :volume do
-  include_context 'test doubles'
-
   let :volumes do
     Array.new(Faker::Number.within(range: 20..150)).map { new_volume }
   end

--- a/spec/hcloud/volume_spec.rb
+++ b/spec/hcloud/volume_spec.rb
@@ -11,8 +11,6 @@ require 'support/it_supports_labels_on_update'
 require 'support/it_supports_action_fetch'
 
 describe Hcloud::Volume, doubles: :volume do
-  include_context 'test doubles'
-
   let :volumes do
     Array.new(Faker::Number.within(range: 20..150)).map { new_volume }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,8 @@ deep_load Hcloud
 RSpec.configure do |c|
   Faker::Config.random = Random.new(c.seed)
 
+  c.include_context 'test doubles', :doubles
+
   if ENV['LEGACY_TESTS']
     require 'webmock/rspec'
     c.before(:each) do


### PR DESCRIPTION
We can use `include_context` on the global rspec config with a tag filter to automatically include the context for all tests marked with that tag. This brings two advantages:

* we do not have to list the include in each test, anymore
* we ensure that all doubles tests are actually tagged with `doubles`