### PR TITLE
server: return `next_actions` data on create

### DIFF
--- a/lib/hcloud/server_resource.rb
+++ b/lib/hcloud/server_resource.rb
@@ -20,7 +20,10 @@ module Hcloud
         [
           Action.new(client, response.parsed_json[:action]),
           Server.new(client, response.parsed_json[:server]),
-          response.parsed_json[:root_password]
+          response.parsed_json[:root_password],
+          response.parsed_json[:next_actions].to_a.map do |action|
+            Action.new(client, action)
+          end
         ]
       end
     end


### PR DESCRIPTION
When a server is created, it can return a field `next_actions` containing actions that will be executed after the server was created. Most commonly, this contains `start_server`. But for example if we directly pass networks or firewalls, it also contains the actions for adding the server to the network or applying the firewall to the server.

To cleanly start a server and wait for all actions to complete, we need to know these `next_actions`.

Example from a test run:

```
# next_actions = 
[
#<Hcloud::Action:0x924 {"id"=>881261022, "command"=>"start_server", "status"=>"running", "progress"=>0,
"started"=>2023-01-27 12:51:55 +0000, "finished"=>nil, "resources"=>[{"id"=>28067295, "type"=>"server"}],
"error"=>nil}>,
#<Hcloud::Action:0x938 {"id"=>881261023, "command"=>"attach_to_network",
"status"=>"running", "progress"=>0, "started"=>2023-01-27 12:51:55 +0000, "finished"=>nil,
"resources"=>[{"id"=>28067295, "type"=>"server"}, {"id"=>2450993, "type"=>"network"}],
"error"=>nil}>
]
```