### PR TITLE
Dependencies: Drop rake, as it's unnecessary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
     rack-accept (0.4.5)
       rack (>= 0.4)
     rainbow (3.1.1)
-    rake (13.0.6)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rspec (3.12.0)
@@ -135,7 +134,6 @@ DEPENDENCIES
   grape
   hcloud!
   pry
-  rake
   rspec
   rubocop
   webmock

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-require 'bundler/gem_tasks'
-task default: :spec

--- a/hcloud.gemspec
+++ b/hcloud.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activemodel'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'grape'
-  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'
   spec.add_runtime_dependency 'activemodel'


### PR DESCRIPTION
Superseds #73 

Suggested: https://github.com/tonobo/hcloud-ruby/pull/70#issuecomment-1401467647