### PR TITLE
lib: import active_support before cherry-picking imports

### DIFF
--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'hcloud/version'
+require 'active_support'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/hash/indifferent_access'
 


### PR DESCRIPTION
With an update to `activesupport-7.1.0` downstream libraries using hcloud-ruby ran into exceptions in activesupport. This seems to be the case, because we do not import `active_support` before any other imports from `active_support`.

According to the docs [1] one always has to first `require "active_support"`, which imports the code needed by activesupport itself. And then we can import actual functionality by importing `active_support/all`, `active_support/core_ext/hash/indifferent_access` or something else.

[1] https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support