### PR TITLE
Dont list activemodel as dev- and runtime dep

### DIFF
--- a/hcloud.gemspec
+++ b/hcloud.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'activemodel'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'grape'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
activemodel is a runtime dependency, it doesn't need to be listed as development dependency as well.