### PR TITLE
CI: Run on PRs and pushes to master

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,12 @@
+---
 name: hcloud-ruby ci
-on: [push]
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures that the CI runs on PRs from external contributors as well. Previously it on run when the PR was raised from a branch in the main repo.