### PR TITLE
(#82) fix undefined method `.blank?`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,31 +3,42 @@ PATH
   specs:
     hcloud (1.2.0)
       activemodel
+      activesupport
       oj
       typhoeus
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4)
-      activesupport (= 7.0.4)
-    activesupport (7.0.4)
+    activemodel (7.1.1)
+      activesupport (= 7.1.1)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     builder (3.2.4)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.1.1)
+      ruby2_keywords
     dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
@@ -47,8 +58,8 @@ GEM
     faker (3.0.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
-    grape (1.6.2)
-      activesupport
+    grape (1.8.0)
+      activesupport (>= 5)
       builder
       dry-types (>= 1.1)
       mustermann-grape (~> 1.0.0)
@@ -64,6 +75,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.0.2)
       mustermann (>= 1.0.0)
+    mutex_m (0.1.2)
     oj (3.16.1)
     parallel (1.22.1)
     parser (3.1.3.0)
@@ -127,7 +139,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activemodel
   bundler
   codecov
   faker

--- a/hcloud.gemspec
+++ b/hcloud.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'
   spec.add_runtime_dependency 'activemodel'
+  spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'oj'
   spec.add_runtime_dependency 'typhoeus'
 end

--- a/lib/hcloud.rb
+++ b/lib/hcloud.rb
@@ -4,6 +4,7 @@ require 'hcloud/version'
 require 'active_support'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/object/blank'
 
 module Hcloud
   autoload :Error, 'hcloud/errors'


### PR DESCRIPTION
This adds the activesupport dependency which provides `.blank?`. It's used in a lot of places so I added the dependency instead of switching to native ruby.

```
$ git grep .blank?
lib/hcloud/certificate_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/certificate_resource.rb:        raise Hcloud::Error::InvalidInput, 'no certificate given' if certificate.blank?
lib/hcloud/certificate_resource.rb:        raise Hcloud::Error::InvalidInput, 'no private_key given' if private_key.blank?
lib/hcloud/entry_loader.rb:          raise Hcloud::Error::InvalidInput, 'no type given' if kwargs[:type].blank?
lib/hcloud/entry_loader.rb:          raise Hcloud::Error::InvalidInput, 'no start given' if kwargs[:start].blank?
lib/hcloud/entry_loader.rb:          raise Hcloud::Error::InvalidInput, 'no end given' if kwargs[:end].blank?
lib/hcloud/firewall_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/floating_ip.rb:      raise Hcloud::Error::InvalidInput, 'no IP given' if ip.blank?
lib/hcloud/floating_ip_resource.rb:      raise Hcloud::Error::InvalidInput, 'no type given' if type.blank?
lib/hcloud/load_balancer.rb:      raise Hcloud::Error::InvalidInput, 'no IP given' if ip.blank?
lib/hcloud/load_balancer.rb:      raise Hcloud::Error::InvalidInput, 'no dns_ptr given' if dns_ptr.blank?
lib/hcloud/load_balancer.rb:      raise Hcloud::Error::InvalidInput, 'no type given' if load_balancer_type.blank?
lib/hcloud/load_balancer.rb:      raise Hcloud::Error::InvalidInput, 'no type given' if type.blank?
lib/hcloud/load_balancer.rb:      raise Hcloud::Error::InvalidInput, 'no protocol given' if protocol.blank?
lib/hcloud/load_balancer.rb:        raise Hcloud::Error::InvalidInput, 'no IP given' if ip.blank?
lib/hcloud/load_balancer_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/load_balancer_resource.rb:      raise Hcloud::Error::InvalidInput, 'no type given' if load_balancer_type.blank?
lib/hcloud/load_balancer_resource.rb:      if !algorithm.to_h.key?(:type) || algorithm[:type].blank?
lib/hcloud/load_balancer_resource.rb:      if location.blank? && network_zone.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no type given' if type.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no network_zone given' if network_zone.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no ip_range given' if ip_range.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no destination given' if destination.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no gateway given' if gateway.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no destination given' if destination.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no gateway given' if gateway.blank?
lib/hcloud/network.rb:      raise Hcloud::Error::InvalidInput, 'no ip_range given' if ip_range.blank?
lib/hcloud/network_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/network_resource.rb:      raise Hcloud::Error::InvalidInput, 'no IP range given' if ip_range.blank?
lib/hcloud/placement_group_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/primary_ip.rb:      raise Hcloud::Error::InvalidInput, 'no IP given' if ip.blank?
lib/hcloud/primary_ip_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/primary_ip_resource.rb:      raise Hcloud::Error::InvalidInput, 'no assignee_type given' if assignee_type.blank?
lib/hcloud/server.rb:      raise Hcloud::Error::InvalidInput, 'no image given' if image.blank?
lib/hcloud/server.rb:      raise Hcloud::Error::InvalidInput, 'no server_type given' if server_type.blank?
lib/hcloud/server.rb:      raise Hcloud::Error::InvalidInput, 'no iso given' if iso.blank?
lib/hcloud/server.rb:      raise Hcloud::Error::InvalidInput, 'no IP given' if ip.blank?
lib/hcloud/server.rb:      raise Hcloud::Error::InvalidInput, 'no dns_ptr given' if dns_ptr.blank?
lib/hcloud/ssh_key_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/volume_resource.rb:      raise Hcloud::Error::InvalidInput, 'no name given' if name.blank?
lib/hcloud/volume_resource.rb:      if location.blank? && server.nil?
```