### PR TITLE
fix activemodel in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activemodel
   bundler
   codecov
   faker


### PR DESCRIPTION
We removed `activemodel` from the development dependencies, but did not update `Gemfile.lock`. This broke the CI runs.